### PR TITLE
Refactor BaseOptimizer object structure

### DIFF
--- a/pypfopt/base_optimizer.py
+++ b/pypfopt/base_optimizer.py
@@ -1,22 +1,67 @@
 # TODO module docstring
 
 import numpy as np
+import pandas as pd
+from . import objective_functions
 
 
 class BaseOptimizer:
-    def __init__(self, n_assets, weight_bounds=(0, 1)):
+    def __init__(self, n_assets, tickers=None):
+        """
+        :param n_assets: number of assets
+        :type n_assets: int
+        :param tickers: name of assets
+        :type tickers: list
+        """
+        self.n_assets = n_assets
+        if tickers is None:
+            self.tickers = list(range(n_assets))
+        else:
+            self.tickers = tickers
+        # Outputs
+        self.weights = None
+
+    def set_weights(self, weights):
+        if self.weights is None:
+            self.weights = [0] * self.n_assets
+        for i, k in enumerate(self.tickers):
+            if k in weights:
+                self.weights[i] = weights[k]
+
+    def clean_weights(self, cutoff=1e-4, rounding=5):
+        """
+        Helper method to clean the raw weights, setting any weights whose absolute
+        values are below the cutoff to zero, and rounding the rest.
+
+        :param cutoff: the lower bound, defaults to 1e-4
+        :type cutoff: float, optional
+        :param rounding: number of decimal places to round the weights, defaults to 5.
+                         Set to None if rounding is not desired.
+        :type rounding: int, optional
+        :return: asset weights
+        :rtype: dict
+        """
+        if not isinstance(rounding, int) or rounding < 1:
+            raise ValueError("rounding must be a positive integer")
+        clean_weights = self.weights.copy()
+        clean_weights[np.abs(clean_weights) < cutoff] = 0
+        if rounding is not None:
+            clean_weights = np.round(clean_weights, rounding)
+        return dict(zip(self.tickers, clean_weights))
+
+
+class BaseScipyOptimizer(BaseOptimizer):
+    def __init__(self, n_assets, tickers=None, weight_bounds=(0, 1)):
         """
         :param weight_bounds: minimum and maximum weight of an asset, defaults to (0, 1).
                               Must be changed to (-1, 1) for portfolios with shorting.
         :type weight_bounds: tuple, optional
         """
-        self.n_assets = n_assets
+        super().__init__(n_assets, tickers)
         self.bounds = self._make_valid_bounds(weight_bounds)
         # Optimisation parameters
         self.initial_guess = np.array([1 / self.n_assets] * self.n_assets)
         self.constraints = [{"type": "eq", "fun": lambda x: np.sum(x) - 1}]
-        # Outputs
-        self.weights = None
 
     def _make_valid_bounds(self, test_bounds):
         """
@@ -39,23 +84,54 @@ class BaseOptimizer:
                 raise ValueError("Lower bound is too high")
         return (test_bounds,) * self.n_assets
 
-    def clean_weights(self, cutoff=1e-4, rounding=5):
-        """
-        Helper method to clean the raw weights, setting any weights whose absolute
-        values are below the cutoff to zero, and rounding the rest.
 
-        :param cutoff: the lower bound, defaults to 1e-4
-        :type cutoff: float, optional
-        :param rounding: number of decimal places to round the weights, defaults to 5.
-                         Set to None if rounding is not desired.
-        :type rounding: int, optional
-        :return: asset weights
-        :rtype: dict
-        """
-        if not isinstance(rounding, int) or rounding < 1:
-            raise ValueError("rounding must be a positive integer")
-        clean_weights = self.weights.copy()
-        clean_weights[np.abs(clean_weights) < cutoff] = 0
-        if rounding is not None:
-            clean_weights = np.round(clean_weights, rounding)
-        return dict(zip(self.tickers, clean_weights))
+def portfolio_performance(
+    expected_returns, cov_matrix, weights, verbose=False, risk_free_rate=0.02
+):
+    """
+    After optimising, calculate (and optionally print) the performance of the optimal
+    portfolio. Currently calculates expected return, volatility, and the Sharpe ratio.
+
+    :param expected_returns: expected returns for each asset. Set to None if
+                             optimising for volatility only.
+    :type expected_returns: pd.Series, list, np.ndarray
+    :param cov_matrix: covariance of returns for each asset
+    :type cov_matrix: pd.DataFrame or np.array
+    :param weights: weights or assets
+    :type weights: list, np.array or dict, optional
+    :param verbose: whether performance should be printed, defaults to False
+    :type verbose: bool, optional
+    :param risk_free_rate: risk-free rate of borrowing/lending, defaults to 0.02
+    :type risk_free_rate: float, optional
+    :raises ValueError: if weights have not been calcualted yet
+    :return: expected return, volatility, Sharpe ratio.
+    :rtype: (float, float, float)
+    """
+    if isinstance(weights, dict):
+        if isinstance(expected_returns, pd.Series):
+            tickers = list(expected_returns.index)
+        elif isinstance(cov_matrix, pd.DataFrame):
+            tickers = list(cov_matrix.columns)
+        else:
+            tickers = list(range(len(expected_returns)))
+        newweights = np.zeros(len(tickers))
+        for i, k in enumerate(tickers):
+            if k in weights:
+                newweights[i] = weights[k]
+        if newweights.sum() == 0:
+            raise ValueError("Weights add to zero, or ticker names don't match")
+    elif weights is not None:
+        newweights = np.asarray(weights)
+    else:
+        raise ValueError("Weights is None")
+    sigma = np.sqrt(objective_functions.volatility(newweights, cov_matrix))
+    mu = newweights.dot(expected_returns)
+
+    sharpe = -objective_functions.negative_sharpe(
+        newweights, expected_returns, cov_matrix, risk_free_rate
+    )
+    if verbose:
+        print("Expected annual return: {:.1f}%".format(100 * mu))
+        print("Annual volatility: {:.1f}%".format(100 * sigma))
+        print("Sharpe Ratio: {:.2f}".format(sharpe))
+    return mu, sigma, sharpe

--- a/pypfopt/cla.py
+++ b/pypfopt/cla.py
@@ -1,0 +1,384 @@
+"""
+The ``cla`` module houses the CLA class, which
+generates optimal portfolios using the Critical Line Algorithm as implemented
+by Marcos Lopez de Prado.
+"""
+
+import numbers
+import warnings
+import numpy as np
+import pandas as pd
+import scipy.optimize as sco
+from . import objective_functions, base_optimizer
+
+
+def _infnone(x):
+    return float("-inf") if x is None else x
+
+
+class CLA(base_optimizer.BaseOptimizer):
+    def __init__(self, expected_returns, cov_matrix, weight_bounds=(0, 1)):
+        """
+        :param expected_returns: expected returns for each asset. Set to None if
+                                 optimising for volatility only.
+        :type expected_returns: pd.Series, list, np.ndarray
+        :param cov_matrix: covariance of returns for each asset
+        :type cov_matrix: pd.DataFrame or np.array
+        :param weight_bounds: minimum and maximum weight of an asset, defaults to (0, 1).
+                              Must be changed to (-1, 1) for portfolios with shorting.
+        :type weight_bounds: tuple (float, float) or (list/ndarray, list/ndarray)
+        :raises TypeError: if ``expected_returns`` is not a series, list or array
+        :raises TypeError: if ``cov_matrix`` is not a dataframe or array
+        """
+
+        # Initialize the class
+        self.mean = np.array(expected_returns).reshape((len(expected_returns), 1))
+        if (self.mean == np.ones(self.mean.shape) * self.mean.mean()).all():
+            self.mean[-1, 0] += 1e-5
+        self.expected_returns = self.mean.reshape((len(self.mean),))
+        self.cov_matrix = np.asarray(cov_matrix)
+        if isinstance(weight_bounds[0], numbers.Real):
+            self.lB = np.ones(self.mean.shape) * weight_bounds[0]
+        else:
+            self.lB = np.array(weight_bounds[0]).reshape(self.mean.shape)
+        if isinstance(weight_bounds[0], numbers.Real):
+            self.uB = np.ones(self.mean.shape) * weight_bounds[1]
+        else:
+            self.uB = np.array(weight_bounds[1]).reshape(self.mean.shape)
+        self.w = []  # solution
+        self.l = []  # lambdas
+        self.g = []  # gammas
+        self.f = []  # free weights
+
+        if isinstance(expected_returns, pd.Series):
+            tickers = list(expected_returns.index)
+        else:
+            tickers = list(range(len(self.mean)))
+        super().__init__(len(tickers), tickers)
+
+    def solve(self):
+        # Compute the turning points,free sets and weights
+        f, w = self.init_algo()
+        self.w.append(np.copy(w))  # store solution
+        self.l.append(None)
+        self.g.append(None)
+        self.f.append(f[:])
+        while True:
+            # 1) case a): Bound one free weight
+            l_in = None
+            if len(f) > 1:
+                covarF, covarFB, meanF, wB = self.get_matrices(f)
+                covarF_inv = np.linalg.inv(covarF)
+                j = 0
+                for i in f:
+                    l, bi = self.compute_lambda(
+                        covarF_inv, covarFB, meanF, wB, j, [self.lB[i], self.uB[i]]
+                    )
+                    if _infnone(l) > _infnone(l_in):
+                        l_in, i_in, bi_in = l, i, bi
+                    j += 1
+            # 2) case b): Free one bounded weight
+            l_out = None
+            if len(f) < self.mean.shape[0]:
+                b = self.get_b(f)
+                for i in b:
+                    covarF, covarFB, meanF, wB = self.get_matrices(f + [i])
+                    covarF_inv = np.linalg.inv(covarF)
+                    l, bi = self.compute_lambda(
+                        covarF_inv,
+                        covarFB,
+                        meanF,
+                        wB,
+                        meanF.shape[0] - 1,
+                        self.w[-1][i],
+                    )
+                    if (self.l[-1] == None or l < self.l[-1]) and l > _infnone(l_out):
+                        l_out, i_out = l, i
+            if (l_in == None or l_in < 0) and (l_out == None or l_out < 0):
+                # 3) compute minimum variance solution
+                self.l.append(0)
+                covarF, covarFB, meanF, wB = self.get_matrices(f)
+                covarF_inv = np.linalg.inv(covarF)
+                meanF = np.zeros(meanF.shape)
+            else:
+                # 4) decide lambda
+                if _infnone(l_in) > _infnone(l_out):
+                    self.l.append(l_in)
+                    f.remove(i_in)
+                    w[i_in] = bi_in  # set value at the correct boundary
+                else:
+                    self.l.append(l_out)
+                    f.append(i_out)
+                covarF, covarFB, meanF, wB = self.get_matrices(f)
+                covarF_inv = np.linalg.inv(covarF)
+            # 5) compute solution vector
+            wF, g = self.compute_w(covarF_inv, covarFB, meanF, wB)
+            for i in range(len(f)):
+                w[f[i]] = wF[i]
+            self.w.append(np.copy(w))  # store solution
+            self.g.append(g)
+            self.f.append(f[:])
+            if self.l[-1] == 0:
+                break
+        # 6) Purge turning points
+        self.purge_num_err(10e-10)
+        self.purge_excess()
+
+    def init_algo(self):
+        # Initialize the algo
+        # 1) Form structured array
+        a = np.zeros((self.mean.shape[0]), dtype=[("id", int), ("mu", float)])
+        b = [self.mean[i][0] for i in range(self.mean.shape[0])]  # dump array into list
+        # fill structured array
+        a[:] = list(zip(list(range(self.mean.shape[0])), b))
+        # 2) Sort structured array
+        b = np.sort(a, order="mu")
+        # 3) First free weight
+        i, w = b.shape[0], np.copy(self.lB)
+        while sum(w) < 1:
+            i -= 1
+            w[b[i][0]] = self.uB[b[i][0]]
+        w[b[i][0]] += 1 - sum(w)
+        return [b[i][0]], w
+
+    def compute_bi(self, c, bi):
+        if c > 0:
+            bi = bi[1][0]
+        if c < 0:
+            bi = bi[0][0]
+        return bi
+
+    def compute_w(self, covarF_inv, covarFB, meanF, wB):
+        # 1) compute gamma
+        onesF = np.ones(meanF.shape)
+        g1 = np.dot(np.dot(onesF.T, covarF_inv), meanF)
+        g2 = np.dot(np.dot(onesF.T, covarF_inv), onesF)
+        if wB is None:
+            g, w1 = float(-self.l[-1] * g1 / g2 + 1 / g2), 0
+        else:
+            onesB = np.ones(wB.shape)
+            g3 = np.dot(onesB.T, wB)
+            g4 = np.dot(covarF_inv, covarFB)
+            w1 = np.dot(g4, wB)
+            g4 = np.dot(onesF.T, w1)
+            g = float(-self.l[-1] * g1 / g2 + (1 - g3 + g4) / g2)
+        # 2) compute weights
+        w2 = np.dot(covarF_inv, onesF)
+        w3 = np.dot(covarF_inv, meanF)
+        return -w1 + g * w2 + self.l[-1] * w3, g
+
+    def compute_lambda(self, covarF_inv, covarFB, meanF, wB, i, bi):
+        # 1) C
+        onesF = np.ones(meanF.shape)
+        c1 = np.dot(np.dot(onesF.T, covarF_inv), onesF)
+        c2 = np.dot(covarF_inv, meanF)
+        c3 = np.dot(np.dot(onesF.T, covarF_inv), meanF)
+        c4 = np.dot(covarF_inv, onesF)
+        c = -c1 * c2[i] + c3 * c4[i]
+        if c == 0:
+            return None, None
+        # 2) bi
+        if type(bi) == list:
+            bi = self.compute_bi(c, bi)
+        # 3) Lambda
+        if wB is None:
+            # All free assets
+            return float((c4[i] - c1 * bi) / c), bi
+        else:
+            onesB = np.ones(wB.shape)
+            l1 = np.dot(onesB.T, wB)
+            l2 = np.dot(covarF_inv, covarFB)
+            l3 = np.dot(l2, wB)
+            l2 = np.dot(onesF.T, l3)
+            return float(((1 - l1 + l2) * c4[i] - c1 * (bi + l3[i])) / c), bi
+
+    def get_matrices(self, f):
+        # Slice covarF,covarFB,covarB,meanF,meanB,wF,wB
+        covarF = self.reduce_matrix(self.cov_matrix, f, f)
+        meanF = self.reduce_matrix(self.mean, f, [0])
+        b = self.get_b(f)
+        covarFB = self.reduce_matrix(self.cov_matrix, f, b)
+        wB = self.reduce_matrix(self.w[-1], b, [0])
+        return covarF, covarFB, meanF, wB
+
+    def get_b(self, f):
+        return self.diff_lists(list(range(self.mean.shape[0])), f)
+
+    def diff_lists(self, list1, list2):
+        return list(set(list1) - set(list2))
+
+    def reduce_matrix(self, matrix, listX, listY):
+        # Reduce a matrix to the provided list of rows and columns
+        if len(listX) == 0 or len(listY) == 0:
+            return
+        matrix_ = matrix[:, listY[0] : listY[0] + 1]
+        for i in listY[1:]:
+            a = matrix[:, i : i + 1]
+            matrix_ = np.append(matrix_, a, 1)
+        matrix__ = matrix_[listX[0] : listX[0] + 1, :]
+        for i in listX[1:]:
+            a = matrix_[i : i + 1, :]
+            matrix__ = np.append(matrix__, a, 0)
+        return matrix__
+
+    def purge_num_err(self, tol):
+        # Purge violations of inequality constraints (associated with ill-conditioned covar matrix)
+        i = 0
+        while True:
+            flag = False
+            if i == len(self.w):
+                break
+            if abs(sum(self.w[i]) - 1) > tol:
+                flag = True
+            else:
+                for j in range(self.w[i].shape[0]):
+                    if (
+                        self.w[i][j] - self.lB[j] < -tol
+                        or self.w[i][j] - self.uB[j] > tol
+                    ):
+                        flag = True
+                        break
+            if flag == True:
+                del self.w[i]
+                del self.l[i]
+                del self.g[i]
+                del self.f[i]
+            else:
+                i += 1
+
+    def purge_excess(self):
+        # Remove violations of the convex hull
+        i, repeat = 0, False
+        while True:
+            if repeat == False:
+                i += 1
+            if i == len(self.w) - 1:
+                break
+            w = self.w[i]
+            mu = np.dot(w.T, self.mean)[0, 0]
+            j, repeat = i + 1, False
+            while True:
+                if j == len(self.w):
+                    break
+                w = self.w[j]
+                mu_ = np.dot(w.T, self.mean)[0, 0]
+                if mu < mu_:
+                    del self.w[i]
+                    del self.l[i]
+                    del self.g[i]
+                    del self.f[i]
+                    repeat = True
+                    break
+                else:
+                    j += 1
+
+    def min_volatility(self):
+        """Get the minimum variance solution"""
+        if not self.w:
+            self.solve()
+        var = []
+        for w in self.w:
+            a = np.dot(np.dot(w.T, self.cov_matrix), w)
+            var.append(a)
+        # return min(var)**.5, self.w[var.index(min(var))]
+        self.weights = self.w[var.index(min(var))].reshape((self.n_assets,))
+        return dict(zip(self.tickers, self.weights))
+
+    def max_sharpe(self):
+        """Get the max Sharpe ratio portfolio"""
+        if not self.w:
+            self.solve()
+        # 1) Compute the local max SR portfolio between any two neighbor turning points
+        w_sr, sr = [], []
+        for i in range(len(self.w) - 1):
+            w0 = np.copy(self.w[i])
+            w1 = np.copy(self.w[i + 1])
+            kargs = {"minimum": False, "args": (w0, w1)}
+            a, b = self.golden_section(self.eval_sr, 0, 1, **kargs)
+            w_sr.append(a * w0 + (1 - a) * w1)
+            sr.append(b)
+        # return max(sr), w_sr[sr.index(max(sr))]
+        self.weights = w_sr[sr.index(max(sr))].reshape((self.n_assets,))
+        return dict(zip(self.tickers, self.weights))
+
+    def eval_sr(self, a, w0, w1):
+        # Evaluate SR of the portfolio within the convex combination
+        w = a * w0 + (1 - a) * w1
+        b = np.dot(w.T, self.mean)[0, 0]
+        c = np.dot(np.dot(w.T, self.cov_matrix), w)[0, 0] ** 0.5
+        return b / c
+
+    def golden_section(self, obj, a, b, **kargs):
+        # Golden section method. Maximum if kargs['minimum']==False is passed
+        from math import log, ceil
+
+        tol, sign, args = 1.0e-9, 1, None
+        if "minimum" in kargs and kargs["minimum"] == False:
+            sign = -1
+        if "args" in kargs:
+            args = kargs["args"]
+        numIter = int(ceil(-2.078087 * log(tol / abs(b - a))))
+        r = 0.618033989
+        c = 1.0 - r
+        # Initialize
+        x1 = r * a + c * b
+        x2 = c * a + r * b
+        f1 = sign * obj(x1, *args)
+        f2 = sign * obj(x2, *args)
+        # Loop
+        for i in range(numIter):
+            if f1 > f2:
+                a = x1
+                x1 = x2
+                f1 = f2
+                x2 = c * a + r * b
+                f2 = sign * obj(x2, *args)
+            else:
+                b = x2
+                x2 = x1
+                f2 = f1
+                x1 = r * a + c * b
+                f1 = sign * obj(x1, *args)
+        if f1 < f2:
+            return x1, sign * f1
+        else:
+            return x2, sign * f2
+
+    def efficient_frontier(self, points):
+        """Get the efficient frontier"""
+        mu, sigma, weights = [], [], []
+        # remove the 1, to avoid duplications
+        a = np.linspace(0, 1, points / len(self.w))[:-1]
+        b = list(range(len(self.w) - 1))
+        for i in b:
+            w0, w1 = self.w[i], self.w[i + 1]
+            if i == b[-1]:
+                # include the 1 in the last iteration
+                a = np.linspace(0, 1, points / len(self.w))
+            for j in a:
+                w = w1 * j + (1 - j) * w0
+                weights.append(np.copy(w))
+                mu.append(np.dot(w.T, self.mean)[0, 0])
+                sigma.append(np.dot(np.dot(w.T, self.cov_matrix), w)[0, 0] ** 0.5)
+        return mu, sigma, weights
+
+    def portfolio_performance(self, verbose=False, risk_free_rate=0.02):
+        """
+        After optimising, calculate (and optionally print) the performance of the optimal
+        portfolio. Currently calculates expected return, volatility, and the Sharpe ratio.
+
+        :param verbose: whether performance should be printed, defaults to False
+        :type verbose: bool, optional
+        :param risk_free_rate: risk-free rate of borrowing/lending, defaults to 0.02
+        :type risk_free_rate: float, optional
+        :raises ValueError: if weights have not been calcualted yet
+        :return: expected return, volatility, Sharpe ratio.
+        :rtype: (float, float, float)
+        """
+        return base_optimizer.portfolio_performance(
+            self.expected_returns,
+            self.cov_matrix,
+            self.weights,
+            verbose,
+            risk_free_rate,
+        )

--- a/pypfopt/discrete_allocation.py
+++ b/pypfopt/discrete_allocation.py
@@ -40,7 +40,7 @@ def portfolio(weights, latest_prices, min_allocation=0.01, total_portfolio_value
     :type total_portfolio_value: int/float, optional
     :raises TypeError: if ``weights`` is not a dict
     :raises TypeError: if ``latest_prices`` isn't a series
-    :raises ValueError: if ``0 < min_allocation < 0.3``
+    :raises ValueError: if not ``0 < min_allocation < 0.3``
     :return: the number of shares of each ticker that should be purchased, along with the amount
              of funds leftover.
     :rtype: (dict, float)

--- a/pypfopt/discrete_allocation.py
+++ b/pypfopt/discrete_allocation.py
@@ -3,6 +3,7 @@ The ``discrete_allocation`` module contains functions to generate a discrete
 allocation from continuous weights.
 """
 
+import numbers
 import numpy as np
 import pandas as pd
 
@@ -124,3 +125,126 @@ def portfolio(weights, latest_prices, min_allocation=0.01, total_portfolio_value
 
     num_shares = dict(zip([i[0] for i in nonzero_weights], shares_bought))
     return num_shares, available_funds
+
+
+def portfolio_lp(
+    weights, latest_prices, min_allocation=0.01, total_portfolio_value=10000
+):
+    """
+    For a long only portfolio, convert the continuous weights to a discrete allocation
+    using Mixed Integer Linear Programming. This can be thought of as a clever way to round
+    the continuous weights to an integer number of shares
+
+    :param weights: continuous weights generated from the ``efficient_frontier`` module
+    :type weights: dict
+    :param latest_prices: the most recent price for each asset
+    :type latest_prices: pd.Series or dict
+    :param min_allocation: any weights less than this number are considered negligible,
+                           defaults to 0.01
+    :type min_allocation: float, optional
+    :param total_portfolio_value: the desired total value of the portfolio, defaults to 10000
+    :type total_portfolio_value: int/float, optional
+    :raises TypeError: if ``weights`` is not a dict
+    :raises TypeError: if ``latest_prices`` isn't a series
+    :raises ValueError: if not ``0 < min_allocation < 0.3``
+    :return: the number of shares of each ticker that should be purchased, along with the amount
+             of funds leftover.
+    :rtype: (dict, float)
+    """
+    import pulp
+
+    if not isinstance(weights, dict):
+        raise TypeError("weights should be a dictionary of {ticker: weight}")
+    if not isinstance(latest_prices, (pd.Series, dict)):
+        raise TypeError("latest_prices should be a pd.Series")
+    if min_allocation > 0.3:
+        raise ValueError("min_allocation should be a small float")
+    if total_portfolio_value <= 0:
+        raise ValueError("total_portfolio_value must be greater than zero")
+
+    m = pulp.LpProblem("PfAlloc", pulp.LpMinimize)
+    vals = {}
+    realvals = {}
+    etas = {}
+    abss = {}
+    remaining = pulp.LpVariable("remaining", 0)
+    for k, w in weights.items():
+        if w < min_allocation:
+            continue
+        vals[k] = pulp.LpVariable("x_%s" % k, 0, cat="Integer")
+        realvals[k] = latest_prices[k] * vals[k]
+        etas[k] = w * total_portfolio_value - realvals[k]
+        abss[k] = pulp.LpVariable("u_%s" % k, 0)
+        m += etas[k] <= abss[k]
+        m += -etas[k] <= abss[k]
+    m += remaining == total_portfolio_value - pulp.lpSum(realvals.values())
+    m += pulp.lpSum(abss.values()) + remaining
+    m.solve()
+    results = {k: val.varValue for k, val in vals.items()}
+    return results, remaining.varValue
+
+
+def portfolio_byvalue(
+    weights, steps, min_values, max_values=1e9, total_portfolio_value=10000
+):
+    """
+    For a long only portfolio, convert the continuous weights to a discrete
+    allocation using Mixed Integer Linear Programming. This function assumes
+    that we buy some asset based on value instead of shares, and there is a
+    limit of minimum value and increasing step.
+
+    :param weights: continuous weights generated from the ``efficient_frontier`` module
+    :type weights: dict
+    :param min_values: the minimum value for each asset
+    :type min_values: int/float or dict
+    :param max_values: the maximum value for each asset
+    :type max_values: int/float or dict
+    :param steps: the minimum value increase for each asset
+    :type steps: int/float or dict
+    :param total_portfolio_value: the desired total value of the portfolio, defaults to 10000
+    :type total_portfolio_value: int/float, optional
+    :raises TypeError: if ``weights`` is not a dict
+    :return: the number of value of each ticker that should be purchased,
+    along with the amount of funds leftover.
+    :rtype: (dict, float)
+    """
+    import pulp
+
+    if not isinstance(weights, dict):
+        raise TypeError("weights should be a dictionary of {ticker: weight}")
+    if total_portfolio_value <= 0:
+        raise ValueError("total_portfolio_value must be greater than zero")
+
+    if isinstance(steps, numbers.Real):
+        steps = {k: steps for k in weights}
+    if isinstance(min_values, numbers.Real):
+        min_values = {k: min_values for k in weights}
+    if isinstance(max_values, numbers.Real):
+        max_values = {k: max_values for k in weights}
+
+    m = pulp.LpProblem("PfAlloc", pulp.LpMinimize)
+    vals = {}
+    realvals = {}
+    usevals = {}
+    etas = {}
+    abss = {}
+    remaining = pulp.LpVariable("remaining", 0)
+    for k, w in weights.items():
+        if steps.get(k):
+            vals[k] = pulp.LpVariable("x_%s" % k, 0, cat="Integer")
+            realvals[k] = steps[k] * vals[k]
+            etas[k] = w * total_portfolio_value - realvals[k]
+        else:
+            realvals[k] = vals[k] = pulp.LpVariable("x_%s" % k, 0)
+            etas[k] = w * total_portfolio_value - vals[k]
+        abss[k] = pulp.LpVariable("u_%s" % k, 0)
+        usevals[k] = pulp.LpVariable("b_%s" % k, cat="Binary")
+        m += etas[k] <= abss[k]
+        m += -etas[k] <= abss[k]
+        m += realvals[k] >= usevals[k] * min_values.get(k, steps.get(k, 0))
+        m += realvals[k] <= usevals[k] * max_values.get(k, 1e18)
+    m += remaining == total_portfolio_value - pulp.lpSum(realvals.values())
+    m += pulp.lpSum(abss.values()) + remaining
+    m.solve()
+    results = {k: pulp.value(val) for k, val in realvals.items()}
+    return results, remaining.varValue

--- a/pypfopt/expected_returns.py
+++ b/pypfopt/expected_returns.py
@@ -18,6 +18,17 @@ import warnings
 import pandas as pd
 
 
+def daily_price_returns(prices):
+    """
+    Calculate the daily return DataFrame from the prices of the asset.
+
+    :param prices: adjusted closing prices of the asset, each row is a date
+                   and each column is a ticker/id.
+    :type prices: pd.DataFrame
+    """
+    return prices.pct_change().dropna(how="all")
+
+
 def mean_historical_return(prices, frequency=252):
     """
     Calculate annualised mean (daily) historical return from input (daily) asset prices.
@@ -34,7 +45,7 @@ def mean_historical_return(prices, frequency=252):
     if not isinstance(prices, pd.DataFrame):
         warnings.warn("prices are not in a dataframe", RuntimeWarning)
         prices = pd.DataFrame(prices)
-    daily_returns = prices.pct_change().dropna(how="all")
+    daily_returns = daily_price_returns(prices)
     return daily_returns.mean() * frequency
 
 
@@ -57,5 +68,5 @@ def ema_historical_return(prices, frequency=252, span=500):
     if not isinstance(prices, pd.DataFrame):
         warnings.warn("prices are not in a dataframe", RuntimeWarning)
         prices = pd.DataFrame(prices)
-    daily_returns = prices.pct_change().dropna(how="all")
+    daily_returns = daily_price_returns(prices)
     return daily_returns.ewm(span=span).mean().iloc[-1] * frequency

--- a/pypfopt/risk_models.py
+++ b/pypfopt/risk_models.py
@@ -22,6 +22,7 @@ import warnings
 import numpy as np
 import pandas as pd
 from sklearn import covariance
+from .expected_returns import daily_price_returns
 
 
 def sample_cov(prices, frequency=252):
@@ -40,7 +41,7 @@ def sample_cov(prices, frequency=252):
     if not isinstance(prices, pd.DataFrame):
         warnings.warn("prices are not in a dataframe", RuntimeWarning)
         prices = pd.DataFrame(prices)
-    daily_returns = prices.pct_change().dropna(how="all")
+    daily_returns = daily_price_returns(prices)
     return daily_returns.cov() * frequency
 
 
@@ -65,7 +66,7 @@ def semicovariance(prices, benchmark=0, frequency=252):
     if not isinstance(prices, pd.DataFrame):
         warnings.warn("prices are not in a dataframe", RuntimeWarning)
         prices = pd.DataFrame(prices)
-    daily_returns = prices.pct_change().dropna(how="all")
+    daily_returns = daily_price_returns(prices)
     drops = np.fmin(daily_returns - benchmark, 0)
     return drops.cov() * frequency
 
@@ -110,7 +111,7 @@ def exp_cov(prices, span=180, frequency=252):
         warnings.warn("prices are not in a dataframe", RuntimeWarning)
         prices = pd.DataFrame(prices)
     assets = prices.columns
-    daily_returns = prices.pct_change().dropna(how="all")
+    daily_returns = daily_price_returns(prices)
     N = len(assets)
 
     # Loop over matrix, filling entries with the pairwise exp cov
@@ -192,8 +193,7 @@ class CovarianceShrinkage:
         """
         assets = self.X.columns
         return (
-            pd.DataFrame(raw_cov_array, index=assets,
-                         columns=assets) * self.frequency
+            pd.DataFrame(raw_cov_array, index=assets, columns=assets) * self.frequency
         )
 
     def shrunk_covariance(self, delta=0.2):

--- a/pypfopt/value_at_risk.py
+++ b/pypfopt/value_at_risk.py
@@ -4,15 +4,15 @@ value-at-risk (CVaR) objective, which requires Monte Carlo simulation.
 """
 
 import pandas as pd
-from .base_optimizer import BaseOptimizer
+from .base_optimizer import BaseScipyOptimizer
 from . import objective_functions
 import noisyopt
 
 
-class CVAROpt(BaseOptimizer):
+class CVAROpt(BaseScipyOptimizer):
 
     """
-    A CVAROpt object (inheriting from BaseOptimizer) provides a method for
+    A CVAROpt object (inheriting from BaseScipyOptimizer) provides a method for
     optimising the CVaR (a.k.a expected shortfall) of a portfolio.
 
     Instance variables:
@@ -48,8 +48,8 @@ class CVAROpt(BaseOptimizer):
         if not isinstance(returns, pd.DataFrame):
             raise TypeError("returns are not a dataframe")
         self.returns = returns
-        self.tickers = returns.columns
-        super().__init__(returns.shape[1], weight_bounds)  # bounds
+        tickers = returns.columns
+        super().__init__(len(tickers), tickers, weight_bounds)
 
     def min_cvar(self, s=10000, beta=0.95, random_state=None):
         """

--- a/tests/test_base_optimizer.py
+++ b/tests/test_base_optimizer.py
@@ -58,8 +58,7 @@ def test_clean_weights():
     assert clean_number_tiny_weights == number_tiny_weights
     #  Check rounding
     cleaned_weights_str_length = [len(str(i)) for i in cleaned_weights]
-    assert all([length == 7 or length ==
-                3 for length in cleaned_weights_str_length])
+    assert all([length == 7 or length == 3 for length in cleaned_weights_str_length])
 
 
 def test_clean_weights_short():

--- a/tests/test_cla.py
+++ b/tests/test_cla.py
@@ -1,0 +1,61 @@
+import warnings
+import numpy as np
+import pandas as pd
+import pytest
+from pypfopt.cla import CLA
+from tests.utilities_for_tests import get_data, setup_cla
+from pypfopt import risk_models
+
+
+def test_portfolio_performance():
+    cla = setup_cla()
+    with pytest.raises(ValueError):
+        cla.portfolio_performance()
+    cla.max_sharpe()
+    assert cla.portfolio_performance()
+
+
+def test_cla_inheritance():
+    cla = setup_cla()
+    assert cla.clean_weights
+    assert cla.set_weights
+
+
+def test_max_sharpe_long_only():
+    cla = setup_cla()
+    w = cla.max_sharpe()
+    assert isinstance(w, dict)
+    assert set(w.keys()) == set(cla.tickers)
+    np.testing.assert_almost_equal(cla.weights.sum(), 1)
+
+    np.testing.assert_allclose(
+        cla.portfolio_performance(),
+        (0.3253436657555845, 0.2133353004830236, 1.4281588303044812),
+    )
+
+
+def test_min_volatility():
+    cla = setup_cla()
+    w = cla.min_volatility()
+    assert isinstance(w, dict)
+    assert set(w.keys()) == set(cla.tickers)
+    np.testing.assert_almost_equal(cla.weights.sum(), 1)
+    np.testing.assert_allclose(
+        cla.portfolio_performance(),
+        (0.1793123248125915, 0.15915084514118688, 0.9981061956268638),
+    )
+
+
+def test_max_sharpe_semicovariance():
+    # f
+    df = get_data()
+    cla = setup_cla()
+    cla.covar = risk_models.semicovariance(df, benchmark=0)
+    w = cla.max_sharpe()
+    assert isinstance(w, dict)
+    assert set(w.keys()) == set(cla.tickers)
+    np.testing.assert_almost_equal(cla.weights.sum(), 1)
+    np.testing.assert_allclose(
+        cla.portfolio_performance(),
+        (0.3253436657555845, 0.2133353004830236, 1.4281588303044812),
+    )

--- a/tests/test_expected_returns.py
+++ b/tests/test_expected_returns.py
@@ -5,6 +5,16 @@ from pypfopt import expected_returns
 from tests.utilities_for_tests import get_data
 
 
+def test_returns_dataframe():
+    df = get_data()
+    returns_df = expected_returns.daily_price_returns(df)
+    assert isinstance(returns_df, pd.DataFrame)
+    assert returns_df.shape[1] == 20
+    assert len(returns_df) == 7125
+    assert returns_df.index.is_all_dates
+    assert not ((returns_df > 1) & returns_df.notnull()).any().any()
+
+
 def test_mean_historical_returns_dummy():
     data = pd.DataFrame(
         [

--- a/tests/utilities_for_tests.py
+++ b/tests/utilities_for_tests.py
@@ -2,6 +2,7 @@ import pandas as pd
 from pypfopt import expected_returns
 from pypfopt import risk_models
 from pypfopt.efficient_frontier import EfficientFrontier
+from pypfopt.cla import CLA
 
 
 def get_data():
@@ -15,3 +16,12 @@ def setup_efficient_frontier(data_only=False):
     if data_only:
         return mean_return, sample_cov_matrix
     return EfficientFrontier(mean_return, sample_cov_matrix)
+
+
+def setup_cla(data_only=False):
+    df = get_data()
+    mean_return = expected_returns.mean_historical_return(df)
+    sample_cov_matrix = risk_models.sample_cov(df)
+    if data_only:
+        return mean_return, sample_cov_matrix
+    return CLA(mean_return, sample_cov_matrix)


### PR DESCRIPTION
I think the current BaseOptimizer object inheritance structure is not extensible. Therefore I reorganize the things in base_optimizer.py as:

* BaseOptimizer
  * attributes: n_assets, tickers, weights
  * methods: set_weights(), clean_weights()
* BaseScipyOptimizer(BaseOptimizer)
  * attributes: bounds, initial_guess, constraints
* portfolio_performance()

Then, I move EfficientFrontier and CVAROpt to the BaseScipyOptimizer, and add a HRPOpt(BaseOptimizer). Add a function expected_returns.daily_price_returns() to convert prices to returns. Therefore, we can easily compare between the optimization methods, add new optimization methods, and reuse weight dicts (to evaluate after discrete allocation).

I also add the Critical Line Algorithm written by the authors of HRP to calculate the Efficient Frontier, and two Mixed Integer Linear Programming models to allocate shares or money.