### PR TITLE
add risk-models: constant-correlation & single-index

### DIFF
--- a/tests/test_risk_models.py
+++ b/tests/test_risk_models.py
@@ -177,3 +177,25 @@ def test_oracle_approximating():
     assert list(shrunk_cov.index) == list(df.columns)
     assert list(shrunk_cov.columns) == list(df.columns)
     assert not shrunk_cov.isnull().any().any()
+
+
+def test_constant_correlation():
+    df = get_data()
+    cc = risk_models.ConstantCorrelation(df)
+    shrunk_cov = cc.shrink()
+    assert 0 < cc.delta < 1
+    assert shrunk_cov.shape == (20, 20)
+    assert list(shrunk_cov.index) == list(df.columns)
+    assert list(shrunk_cov.columns) == list(df.columns)
+    assert not shrunk_cov.isnull().any().any()
+
+
+def test_single_index():
+    df = get_data()
+    si = risk_models.SingleIndex(df)
+    shrunk_cov = si.shrink()
+    assert 0 < si.delta < 1
+    assert shrunk_cov.shape == (20, 20)
+    assert list(shrunk_cov.index) == list(df.columns)
+    assert list(shrunk_cov.columns) == list(df.columns)
+    assert not shrunk_cov.isnull().any().any()


### PR DESCRIPTION
Hi @robertmartin8,

From here: https://github.com/robertmartin8/PyPortfolioOpt/issues/20, I open a pull request and could you review it. I tried to keep variables as same as the author's code so you can check it with the original source code (matlab).