### PR TITLE
Fixed portfolio_performance function 

### DIFF
--- a/pypfopt/base_optimizer.py
+++ b/pypfopt/base_optimizer.py
@@ -134,7 +134,7 @@ def portfolio_performance(
     mu = newweights.dot(expected_returns)
 
     sharpe = -objective_functions.negative_sharpe(
-        newweights, expected_returns, cov_matrix, risk_free_rate
+        newweights, expected_returns, cov_matrix, risk_free_rate = risk_free_rate
     )
     if verbose:
         print("Expected annual return: {:.1f}%".format(100 * mu))


### PR DESCRIPTION
Fixed portfolio_performance function, which while calling objective_functions.negative_sharpe function passed risk_free_rate as gamma argument for L2 regularization instead of risk free rate. This resulted in wrong Sharpe ratio.