### PR TITLE
Allow None as Rounding Precision in `clean_weights`

### DIFF
--- a/pypfopt/base_optimizer.py
+++ b/pypfopt/base_optimizer.py
@@ -52,11 +52,11 @@ class BaseOptimizer:
         :return: asset weights
         :rtype: dict
         """
-        if not isinstance(rounding, int) or rounding < 1:
-            raise ValueError("rounding must be a positive integer")
         clean_weights = self.weights.copy()
         clean_weights[np.abs(clean_weights) < cutoff] = 0
         if rounding is not None:
+            if not isinstance(rounding, int) or rounding < 1:
+                raise ValueError("rounding must be a positive integer")
             clean_weights = np.round(clean_weights, rounding)
         return dict(zip(self.tickers, clean_weights))
 

--- a/tests/test_base_optimizer.py
+++ b/tests/test_base_optimizer.py
@@ -92,7 +92,7 @@ def test_clean_weights_no_rounding():
     # in previous commits, this call would raise a ValueError
     cleaned = ef.clean_weights(rounding=None, cutoff=0)
     assert cleaned
-    np.testing.assert_array_almost_equal(ef.weights, list(cleaned.values()))
+    np.testing.assert_array_almost_equal(np.sort(ef.weights), np.sort(list(cleaned.values())))
 
 
 def test_efficient_frontier_init_errors():

--- a/tests/test_base_optimizer.py
+++ b/tests/test_base_optimizer.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
-from unittest import mock
 from pypfopt.efficient_frontier import EfficientFrontier
 from tests.utilities_for_tests import get_data, setup_efficient_frontier
+
 
 def test_custom_upper_bound():
     ef = EfficientFrontier(
@@ -84,24 +84,15 @@ def test_clean_weights_error():
         ef.clean_weights(rounding=0)
     assert ef.clean_weights(rounding=3)
 
+
 def test_clean_weights_no_rounding():
     ef = setup_efficient_frontier()
     ef.max_sharpe()
     # ensure the call does not fail
     # in previous commits, this call would raise a ValueError
-    assert ef.clean_weights(rounding=None)
-
-    # ensure the call does not round
-    with mock.patch('pypfopt.efficient_frontier.np.round') as rounding_method:
-        # rather than check the weights before and after for rounding, which
-        # could probably have floating point issues, ensure the rounding method,
-        # `np.round` is not called
-        ef.clean_weights(rounding=None)
-        assert rounding_method.call_count == 0
-
-        # sanity check to ensure the mock has been created correctly
-        ef.clean_weights(rounding=1)
-        assert rounding_method.call_count == 1
+    cleaned = ef.clean_weights(rounding=None, cutoff=0)
+    assert cleaned
+    np.testing.assert_array_almost_equal(ef.weights, list(cleaned.values()))
 
 
 def test_efficient_frontier_init_errors():


### PR DESCRIPTION
the documentation of `BaseOptimizer#clean_weights` suggests that `None` is an acceptable rounding value (meaning, "no rounding"), however, there is data validation which requires it be an integer greater than 0.

This commit moves the validation within the `rounding is not None` condition with a new test to ensure rounding is not being performed.