### PR TITLE
Add Black-Litterman model

### DIFF
--- a/pypfopt/risk_models.py
+++ b/pypfopt/risk_models.py
@@ -154,6 +154,42 @@ def min_cov_determinant(prices, frequency=252, random_state=None):
     return pd.DataFrame(raw_cov_array, index=assets, columns=assets) * frequency
 
 
+def black_litterman_cov(Sigma, Omega=None, P=None, tau=0.05):
+    """
+    Calculate the expected posterior covariance matrix according to the Black-Litterman model.
+
+    This function receives a previous estimate of the covariance matrix.
+
+    :param Sigma: the (symmetric) covariance matrix estimate
+    :type Sigma: pd.DataFrame
+    :param Omega: a (diagonal) matrix that identifies the uncertainty in the views (default is the diagonal of :math:`\tau P \Sigma P^T`)
+    :type Omega: pd.DataFrame, optional
+    :param P: the matrix that identifies the asset involved in the different views (default is identity)
+    :type P: pd.DataFrame, optional
+    :param tau: the weight-on-views scalar (default is 0.05)
+    :type tau: float, optional
+    :return: the expected posterior covariance matrix
+    :rtype: pd.DataFrame
+    """
+    if P is None:
+        P = np.eye(Sigma.shape[0])
+    if Omega is None:
+        Omega = np.diag(np.diag(tau * P @ Sigma @ P.T))
+
+    Omega_inv = np.diag(1.0 / np.diag(Omega))
+    P_Omega_inv = P.T @ Omega_inv
+    tau_Sigma_inv = np.linalg.inv(tau * Sigma)
+
+    # # Older method
+    # b = P @ Sigma
+    # A = tau * b @ P.T + Omega
+    # B = b.T @ np.linalg.solve(A, b)
+    # return (1.0 + tau) * Sigma - tau**2 * B
+
+    M = np.linalg.inv(tau_Sigma_inv + P_Omega_inv @ P)
+    return Sigma + M
+
+
 def cov_to_corr(cov_matrix):
     """
     Convert a covariance matrix to a correlation matrix.

--- a/tests/test_expected_returns.py
+++ b/tests/test_expected_returns.py
@@ -1,7 +1,7 @@
 import warnings
 import pandas as pd
 import numpy as np
-from pypfopt import expected_returns
+from pypfopt import expected_returns, risk_models
 from tests.utilities_for_tests import get_data
 
 
@@ -118,3 +118,15 @@ def test_ema_historical_return_limit():
     sma = expected_returns.mean_historical_return(df)
     ema = expected_returns.ema_historical_return(df, span=1e10)
     np.testing.assert_array_almost_equal(ema.values, sma.values)
+
+
+def test_black_litterman_return_default():
+    df = get_data()
+    Pi = expected_returns.ema_historical_return(df)
+    Sigma = risk_models.CovarianceShrinkage(df).ledoit_wolf()
+    Q = pd.Series(0.1, index=Pi.index)
+    mean = expected_returns.black_litterman_return(Pi, Sigma, Q)
+    assert isinstance(mean, pd.Series)
+    assert list(mean.index) == list(df.columns)
+    assert mean.notnull().all()
+    assert mean.dtype == "float64"

--- a/tests/test_risk_models.py
+++ b/tests/test_risk_models.py
@@ -220,3 +220,13 @@ def test_oracle_approximating():
     assert list(shrunk_cov.index) == list(df.columns)
     assert list(shrunk_cov.columns) == list(df.columns)
     assert not shrunk_cov.isnull().any().any()
+
+
+def test_black_litterman_cov_default():
+    df = get_data()
+    Sigma = risk_models.CovarianceShrinkage(df).ledoit_wolf()
+    S = risk_models.black_litterman_cov(Sigma)
+    assert S.shape == (20, 20)
+    assert S.index.equals(df.columns)
+    assert S.index.equals(S.columns)
+    assert S.notnull().all().all()


### PR DESCRIPTION
This implements the [Black-Litterman model](https://en.wikipedia.org/wiki/Black%E2%80%93Litterman_model), as discussed in #48 (a previous PR can be found at #53). Basically, it implements and (minimally) tests two functions:

- `expected_returns.black_litterman_return`
- `risk_models.black_litterman_cov` [as found in [He and Litterman (2002)](https://dx.doi.org/10.2139/ssrn.334304)]

Implementation is based on equations (11) and (16) from [here](https://fam.tuwien.ac.at/~sgerhold/pub_files/sem16/s_polovenko.pdf) (further references can be found in this document as well).

To make it as easy to use as possible, while retaining the full functionality of the implementation,

- I kept variable names as close as possible to the standard literature;
- I made extensive use of default values (particularly for `Omega`, `P` and `tau`). For this, I used common choices such as `P` being identity and `tau` equal to `0.05`. All defaults were taken from the choices made in [this work](http://lup.lub.lu.se/luur/download?func=downloadFile&recordOId=5472145&fileOId=5472158).

There are probably more to be done such as documentation (we need equations and references!) and more tests (particularly, we might need to test, at least, the usage of views `Q` in `expected_returns.black_litterman_return`). I'm open to suggestions on both.