### PR TITLE
Exposed choice of linkage

### DIFF
--- a/pypfopt/hierarchical_portfolio.py
+++ b/pypfopt/hierarchical_portfolio.py
@@ -139,13 +139,16 @@ class HRPOpt(base_optimizer.BaseOptimizer):
                 w[second_cluster] *= 1 - alpha  # weight 2
         return w
 
-    def optimize(self):
+    def optimize(self, linkage_method="single"):
         """
         Construct a hierarchical risk parity portfolio
 
         :return: weights for the HRP portfolio
         :rtype: OrderedDict
         """
+        if linkage_method not in sch._LINKAGE_METHODS:
+            raise ValueError("linkage_method must be one recognised by scipy")
+
         if self.returns is None:
             cov = self.cov_matrix
             corr = risk_models.cov_to_corr(self.cov_matrix).round(6)
@@ -159,7 +162,7 @@ class HRPOpt(base_optimizer.BaseOptimizer):
         matrix = np.sqrt(np.clip((1.0 - corr) / 2.0, a_min=0.0, a_max=1.0))
         dist = ssd.squareform(matrix, checks=False)
 
-        self.clusters = sch.linkage(dist, "single")
+        self.clusters = sch.linkage(dist, linkage_method)
         sort_ix = HRPOpt._get_quasi_diag(self.clusters)
         ordered_tickers = corr.index[sort_ix].tolist()
         hrp = HRPOpt._raw_hrp_allocation(cov, ordered_tickers)

--- a/tests/test_hrp.py
+++ b/tests/test_hrp.py
@@ -10,7 +10,7 @@ def test_hrp_portfolio():
     df = get_data()
     returns = df.pct_change().dropna(how="all")
     hrp = HRPOpt(returns)
-    w = hrp.optimize()
+    w = hrp.optimize(linkage_method="single")
 
     # uncomment this line if you want generating a new file
     # pd.Series(w).to_csv(resource("weights_hrp.csv"))
@@ -32,7 +32,7 @@ def test_portfolio_performance():
     hrp = HRPOpt(returns)
     with pytest.raises(ValueError):
         hrp.portfolio_performance()
-    hrp.optimize()
+    hrp.optimize(linkage_method="single")
     np.testing.assert_allclose(
         hrp.portfolio_performance(),
         (0.21353402380950973, 0.17844159743748936, 1.084579081272277),
@@ -43,7 +43,7 @@ def test_pass_cov_matrix():
     df = get_data()
     S = CovarianceShrinkage(df).ledoit_wolf()
     hrp = HRPOpt(cov_matrix=S)
-    hrp.optimize()
+    hrp.optimize(linkage_method="single")
     perf = hrp.portfolio_performance()
     assert perf[0] is None and perf[2] is None
     np.testing.assert_almost_equal(perf[1], 0.10002783894982334)
@@ -62,6 +62,6 @@ def test_quasi_dag():
     df = get_data()
     returns = df.pct_change().dropna(how="all")
     hrp = HRPOpt(returns)
-    hrp.optimize()
+    hrp.optimize(linkage_method="single")
     clusters = hrp.clusters
     assert HRPOpt._get_quasi_diag(clusters)[:5] == [12, 6, 15, 14, 2]


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
`pypfopt.hierarchical_portfolio.HRPOpt` currently does not allow users to choose the linkage method used in hierarchical clustering. Utilising correlation structure is the main selling point of HRP, and it would be great to give users more control over that process. (Does single linkage, the default in HRP, always make sense?)

**Describe the solution you'd like**
I added one keyword argument to `HRPOpt.optimize()`; it now takes a string `linkage_method` and references it when performing h. clustering. In the same method, I have also added a check, so that Python raises `ValueError` when `scipy` doesn't recognise `linkage_method` . Updated all unit tests to explicitly use `single` linkage which is HRP's published default, ran the tests and confirmed that code is still sound.

**Additional context**
`mlfinlab`, another quant library endorsed by de Prado, already has what I described. See the `allocate` method's [signature](https://mlfinlab.readthedocs.io/en/latest/portfolio_optimisation/hierarchical_risk_parity.html)