### PR TITLE
Risk model semivariance (Issue #219)

### DIFF
--- a/pypfopt/risk_models.py
+++ b/pypfopt/risk_models.py
@@ -205,8 +205,9 @@ def semicovariance(
     else:
         returns = returns_from_prices(prices)
     drops = np.fmin(returns - benchmark, 0)
+    T = len(drops.index)
     return fix_nonpositive_semidefinite(
-        drops.cov() * frequency, kwargs.get("fix_method", "spectral")
+        (drops.T @ drops) / T * frequency, kwargs.get("fix_method", "spectral")
     )
 
 

--- a/tests/test_cla.py
+++ b/tests/test_cla.py
@@ -99,7 +99,7 @@ def test_cla_max_sharpe_semicovariance():
     np.testing.assert_almost_equal(cla.weights.sum(), 1)
     np.testing.assert_allclose(
         cla.portfolio_performance(),
-        (0.2686858719299194, 0.06489248187610204, 3.8322755539652578),
+        (0.2721798377099145, 0.07258537193305141, 3.474251505420551),
     )
 
 

--- a/tests/test_efficient_frontier.py
+++ b/tests/test_efficient_frontier.py
@@ -1076,7 +1076,7 @@ def test_max_sharpe_semicovariance():
     assert all([i >= 0 for i in w.values()])
     np.testing.assert_allclose(
         ef.portfolio_performance(),
-        (0.2732301946250426, 0.06603231922971581, 3.834943215368455),
+        (0.2762965426962885, 0.07372667096108301, 3.476307004714425),
     )
 
 
@@ -1092,7 +1092,7 @@ def test_max_sharpe_short_semicovariance():
     np.testing.assert_almost_equal(ef.weights.sum(), 1)
     np.testing.assert_allclose(
         ef.portfolio_performance(),
-        (0.3907992623559733, 0.0809285460933456, 4.581810501430255),
+        (0.42444834528495234, 0.0898263632679403, 4.50255727350929),
     )
 
 


### PR DESCRIPTION
Use 
![image](https://user-images.githubusercontent.com/44360364/100211088-fd8db380-2f0b-11eb-9826-d8c35f755e03.png)
to compute the semicovariance matrix, as raised in #219 .