### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,12 @@
-FROM python:3.8-slim-buster
+FROM python:3.8-buster
 
 WORKDIR pypfopt
 COPY pyproject.toml poetry.lock ./
 
-RUN buildDeps='gcc g++' && \
-    apt-get update && apt-get install -y $buildDeps --no-install-recommends && \
-    pip install --upgrade pip==21.0.1 && \
+RUN pip install --upgrade pip==21.0.1 && \
     pip install "poetry==1.1.4" && \
     pip install yfinance && \
-    poetry install -E optionals --no-root && \
-    apt-get purge -y --auto-remove $buildDeps
+    poetry install -E optionals --no-root 
 
 COPY . .
 


### PR DESCRIPTION
buster package is larger but no need to install the build dependencies. Come out of the box.
https://medium.com/swlh/alpine-slim-stretch-buster-jessie-bullseye-bookworm-what-are-the-differences-in-docker-62171ed4531d

Good work with Poetry.