### PR TITLE
Fix missing solver for short and long portfolio allocation

### DIFF
--- a/pypfopt/discrete_allocation.py
+++ b/pypfopt/discrete_allocation.py
@@ -285,7 +285,7 @@ class DiscreteAllocation:
             da1 = DiscreteAllocation(
                 longs, self.latest_prices[longs.keys()], total_portfolio_value=long_val
             )
-            long_alloc, long_leftover = da1.lp_portfolio()
+            long_alloc, long_leftover = da1.lp_portfolio(solver=solver)
 
             if verbose:
                 print("\nAllocating short sub-portfolio:")
@@ -294,7 +294,7 @@ class DiscreteAllocation:
                 self.latest_prices[shorts.keys()],
                 total_portfolio_value=short_val,
             )
-            short_alloc, short_leftover = da2.lp_portfolio()
+            short_alloc, short_leftover = da2.lp_portfolio(solver=solver)
             short_alloc = {t: -w for t, w in short_alloc.items()}
 
             # Combine and return


### PR DESCRIPTION
lp_portfolio() without arguments defaults to GLPK_MI as solver. This results in a "Solver is not installed" error in the case that cvxopt package is not installed and only a different solver, e.g. gurobipy (GUROBI) is installed.