### PR TITLE
Fix typo in warning message

### DIFF
--- a/pypfopt/plotting.py
+++ b/pypfopt/plotting.py
@@ -183,7 +183,7 @@ def _plot_ef(ef, ef_param, ef_param_range, ax, show_assets):
             continue
         except ValueError:
             warnings.warn(
-                "Could not construct portfolio for paramter value {:.3f}".format(
+                "Could not construct portfolio for parameter value {:.3f}".format(
                     param_value
                 )
             )


### PR DESCRIPTION
I found a typo in a warning message in the  helper function to plot the efficient frontier from an EfficientFrontier object.
