### PR TITLE
Remove hardcoded versions from dockerfile#507

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,9 +3,8 @@ FROM python:3.8-buster
 WORKDIR pypfopt
 COPY pyproject.toml poetry.lock ./
 
-RUN pip install --upgrade pip==21.0.1 && \
-    pip install "poetry==1.1.4" && \
-    pip install yfinance && \
+RUN pip install --upgrade pip \
+    pip install poetry yfinance && \
     poetry install -E optionals --no-root 
 
 COPY . .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-buster
+FROM python:3.9-slim
 
 WORKDIR pypfopt
 COPY pyproject.toml poetry.lock ./


### PR DESCRIPTION
### Host env
```
$ grep VERSION /etc/os-release && uname -a && docker -v
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
Linux localhost 5.10.0-20-amd64 #1 SMP Debian 5.10.158-2 (2022-12-13) x86_64 GNU/Linux
Docker version 20.10.22, build 3a2c30b
```
### Test command
```
$ cat run_docker_test.sh 
docker build -f docker/Dockerfile . -t pypfopt && \
docker run --name tests_pypfopt -t pypfopt bash -c 'cat /etc/os-release && python -V && poetry run pytest'
```

### Test log
```
$ bash run_docker_test.sh 
Sending build context to Docker daemon  18.04MB
Step 1/6 : FROM python:3.9-slim
3.9-slim: Pulling from library/python
3f4ca61aafcd: Pull complete 
3f487a3359db: Pull complete 
ae22731824be: Pull complete 
3583ac268677: Pull complete 
de224c04316a: Pull complete 
Digest: sha256:9e0b4391fc41bc35c16caef4740736b6b349f6626fd14eba32793ae3c7b01908
Status: Downloaded newer image for python:3.9-slim
 ---> e2f464551004
Step 2/6 : WORKDIR pypfopt
 ---> Running in dd791859addc
Removing intermediate container dd791859addc
 ---> 13e595ab1a9c
Step 3/6 : COPY pyproject.toml poetry.lock ./
 ---> 83fb9a7c316d
Step 4/6 : RUN pip install --upgrade pip     pip install poetry yfinance &&     poetry install -E optionals --no-root
 ---> Running in 000b65f1574a
Requirement already satisfied: pip in /usr/local/lib/python3.9/site-packages (22.0.4)
Collecting pip
  Downloading pip-22.3.1-py3-none-any.whl (2.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.1/2.1 MB 5.9 MB/s eta 0:00:00
Collecting install
  Downloading install-1.3.5-py3-none-any.whl (3.2 kB)
Collecting poetry
  Downloading poetry-1.3.1-py3-none-any.whl (218 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 218.9/218.9 KB 2.8 MB/s eta 0:00:00
Collecting yfinance
  Downloading yfinance-0.2.3-py2.py3-none-any.whl (50 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 50.4/50.4 KB 591.1 kB/s eta 0:00:00
Collecting keyring<24.0.0,>=23.9.0
  Downloading keyring-23.13.1-py3-none-any.whl (37 kB)
Collecting packaging>=20.4
  Downloading packaging-22.0-py3-none-any.whl (42 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 42.6/42.6 KB 581.3 kB/s eta 0:00:00
Collecting cleo<3.0.0,>=2.0.0
  Downloading cleo-2.0.1-py3-none-any.whl (77 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 77.3/77.3 KB 1.1 MB/s eta 0:00:00
Collecting filelock<4.0.0,>=3.8.0
  Downloading filelock-3.8.2-py3-none-any.whl (10 kB)
Collecting urllib3<2.0.0,>=1.26.0
  Downloading urllib3-1.26.13-py2.py3-none-any.whl (140 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 140.6/140.6 KB 2.2 MB/s eta 0:00:00
Collecting cachecontrol[filecache]<0.13.0,>=0.12.9
  Downloading CacheControl-0.12.11-py2.py3-none-any.whl (21 kB)
Collecting trove-classifiers>=2022.5.19
  Downloading trove_classifiers-2022.12.22-py3-none-any.whl (13 kB)
Collecting tomli<3.0.0,>=2.0.1
  Downloading tomli-2.0.1-py3-none-any.whl (12 kB)
Collecting dulwich<0.21.0,>=0.20.46
  Downloading dulwich-0.20.50-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (499 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 499.4/499.4 KB 4.1 MB/s eta 0:00:00
Collecting poetry-plugin-export<2.0.0,>=1.2.0
  Downloading poetry_plugin_export-1.2.0-py3-none-any.whl (10 kB)
Collecting virtualenv!=20.4.5,!=20.4.6,<21.0.0,>=20.4.3
  Downloading virtualenv-20.17.1-py3-none-any.whl (8.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.8/8.8 MB 7.0 MB/s eta 0:00:00
Collecting requests-toolbelt<0.11.0,>=0.9.1
  Downloading requests_toolbelt-0.10.1-py2.py3-none-any.whl (54 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 54.5/54.5 KB 798.6 kB/s eta 0:00:00
Collecting jsonschema<5.0.0,>=4.10.0
  Downloading jsonschema-4.17.3-py3-none-any.whl (90 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 90.4/90.4 KB 1.4 MB/s eta 0:00:00
Collecting poetry-core==1.4.0
  Downloading poetry_core-1.4.0-py3-none-any.whl (546 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 546.4/546.4 KB 4.4 MB/s eta 0:00:00
Collecting pkginfo<2.0,>=1.5
  Downloading pkginfo-1.9.2-py3-none-any.whl (26 kB)
Collecting platformdirs<3.0.0,>=2.5.2
  Downloading platformdirs-2.6.0-py3-none-any.whl (14 kB)
Collecting shellingham<2.0,>=1.5
  Downloading shellingham-1.5.0-py2.py3-none-any.whl (9.3 kB)
Collecting html5lib<2.0,>=1.0
  Downloading html5lib-1.1-py2.py3-none-any.whl (112 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 112.2/112.2 KB 1.8 MB/s eta 0:00:00
Collecting requests<3.0,>=2.18
  Downloading requests-2.28.1-py3-none-any.whl (62 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 62.8/62.8 KB 946.8 kB/s eta 0:00:00
Collecting tomlkit!=0.11.2,!=0.11.3,<1.0.0,>=0.11.1
  Downloading tomlkit-0.11.6-py3-none-any.whl (35 kB)
Collecting crashtest<0.5.0,>=0.4.1
  Downloading crashtest-0.4.1-py3-none-any.whl (7.6 kB)
Collecting lockfile<0.13.0,>=0.12.2
  Downloading lockfile-0.12.2-py2.py3-none-any.whl (13 kB)
Collecting pexpect<5.0.0,>=4.7.0
  Downloading pexpect-4.8.0-py2.py3-none-any.whl (59 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 59.0/59.0 KB 772.7 kB/s eta 0:00:00
Collecting importlib-metadata<5.0,>=4.4
  Downloading importlib_metadata-4.13.0-py3-none-any.whl (23 kB)
Collecting lxml>=4.9.1
  Downloading lxml-4.9.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl (7.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 7.1/7.1 MB 7.5 MB/s eta 0:00:00
Collecting multitasking>=0.0.7
  Downloading multitasking-0.0.11-py3-none-any.whl (8.5 kB)
Collecting numpy>=1.16.5
  Downloading numpy-1.24.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 17.3/17.3 MB 6.7 MB/s eta 0:00:00
Collecting appdirs>=1.4.4
  Downloading appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)
Collecting beautifulsoup4>=4.11.1
  Downloading beautifulsoup4-4.11.1-py3-none-any.whl (128 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 128.2/128.2 KB 2.0 MB/s eta 0:00:00
Collecting cryptography>=3.3.2
  Downloading cryptography-38.0.4-cp36-abi3-manylinux_2_28_x86_64.whl (4.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.2/4.2 MB 7.6 MB/s eta 0:00:00
Collecting frozendict>=2.3.4
  Downloading frozendict-2.3.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (112 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 112.6/112.6 KB 1.8 MB/s eta 0:00:00
Collecting pandas>=1.3.0
  Downloading pandas-1.5.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (12.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 12.2/12.2 MB 7.2 MB/s eta 0:00:00
Collecting pytz>=2022.5
  Downloading pytz-2022.7-py2.py3-none-any.whl (499 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 499.4/499.4 KB 4.3 MB/s eta 0:00:00
Collecting soupsieve>1.2
  Downloading soupsieve-2.3.2.post1-py3-none-any.whl (37 kB)
Collecting msgpack>=0.5.2
  Downloading msgpack-1.0.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (322 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 322.4/322.4 KB 3.5 MB/s eta 0:00:00
Collecting rapidfuzz<3.0.0,>=2.2.0
  Downloading rapidfuzz-2.13.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (2.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.2/2.2 MB 6.8 MB/s eta 0:00:00
Collecting cffi>=1.12
  Downloading cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (441 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 441.2/441.2 KB 4.1 MB/s eta 0:00:00
Collecting six>=1.9
  Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting webencodings
  Downloading webencodings-0.5.1-py2.py3-none-any.whl (11 kB)
Collecting zipp>=0.5
  Downloading zipp-3.11.0-py3-none-any.whl (6.6 kB)
Collecting pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
  Downloading pyrsistent-0.19.2-py3-none-any.whl (57 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 57.5/57.5 KB 882.0 kB/s eta 0:00:00
Collecting attrs>=17.4.0
  Downloading attrs-22.2.0-py3-none-any.whl (60 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 60.0/60.0 KB 880.8 kB/s eta 0:00:00
Collecting SecretStorage>=3.2
  Downloading SecretStorage-3.3.3-py3-none-any.whl (15 kB)
Collecting jaraco.classes
  Downloading jaraco.classes-3.2.3-py3-none-any.whl (6.0 kB)
Collecting jeepney>=0.4.2
  Downloading jeepney-0.8.0-py3-none-any.whl (48 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.4/48.4 KB 662.4 kB/s eta 0:00:00
Collecting python-dateutil>=2.8.1
  Downloading python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 247.7/247.7 KB 3.2 MB/s eta 0:00:00
Collecting ptyprocess>=0.5
  Downloading ptyprocess-0.7.0-py2.py3-none-any.whl (13 kB)
Collecting idna<4,>=2.5
  Downloading idna-3.4-py3-none-any.whl (61 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 61.5/61.5 KB 789.2 kB/s eta 0:00:00
Collecting charset-normalizer<3,>=2
  Downloading charset_normalizer-2.1.1-py3-none-any.whl (39 kB)
Collecting certifi>=2017.4.17
  Downloading certifi-2022.12.7-py3-none-any.whl (155 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 155.3/155.3 KB 2.5 MB/s eta 0:00:00
Collecting distlib<1,>=0.3.6
  Downloading distlib-0.3.6-py2.py3-none-any.whl (468 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 468.5/468.5 KB 4.5 MB/s eta 0:00:00
Collecting pycparser
  Downloading pycparser-2.21-py2.py3-none-any.whl (118 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 118.7/118.7 KB 1.7 MB/s eta 0:00:00
Collecting more-itertools
  Downloading more_itertools-9.0.0-py3-none-any.whl (52 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 52.8/52.8 KB 603.7 kB/s eta 0:00:00
Installing collected packages: webencodings, trove-classifiers, pytz, ptyprocess, multitasking, msgpack, lockfile, distlib, appdirs, zipp, urllib3, tomlkit, tomli, soupsieve, six, shellingham, rapidfuzz, pyrsistent, pycparser, poetry-core, platformdirs, pkginfo, pip, pexpect, packaging, numpy, more-itertools, lxml, jeepney, install, idna, frozendict, filelock, crashtest, charset-normalizer, certifi, attrs, virtualenv, requests, python-dateutil, jsonschema, jaraco.classes, importlib-metadata, html5lib, dulwich, cleo, cffi, beautifulsoup4, requests-toolbelt, pandas, cryptography, cachecontrol, yfinance, SecretStorage, keyring, poetry-plugin-export, poetry
  Attempting uninstall: pip
    Found existing installation: pip 22.0.4
    Uninstalling pip-22.0.4:
      Successfully uninstalled pip-22.0.4
Successfully installed SecretStorage-3.3.3 appdirs-1.4.4 attrs-22.2.0 beautifulsoup4-4.11.1 cachecontrol-0.12.11 certifi-2022.12.7 cffi-1.15.1 charset-normalizer-2.1.1 cleo-2.0.1 crashtest-0.4.1 cryptography-38.0.4 distlib-0.3.6 dulwich-0.20.50 filelock-3.8.2 frozendict-2.3.4 html5lib-1.1 idna-3.4 importlib-metadata-4.13.0 install-1.3.5 jaraco.classes-3.2.3 jeepney-0.8.0 jsonschema-4.17.3 keyring-23.13.1 lockfile-0.12.2 lxml-4.9.2 more-itertools-9.0.0 msgpack-1.0.4 multitasking-0.0.11 numpy-1.24.0 packaging-22.0 pandas-1.5.2 pexpect-4.8.0 pip-22.3.1 pkginfo-1.9.2 platformdirs-2.6.0 poetry-1.3.1 poetry-core-1.4.0 poetry-plugin-export-1.2.0 ptyprocess-0.7.0 pycparser-2.21 pyrsistent-0.19.2 python-dateutil-2.8.2 pytz-2022.7 rapidfuzz-2.13.7 requests-2.28.1 requests-toolbelt-0.10.1 shellingham-1.5.0 six-1.16.0 soupsieve-2.3.2.post1 tomli-2.0.1 tomlkit-0.11.6 trove-classifiers-2022.12.22 urllib3-1.26.13 virtualenv-20.17.1 webencodings-0.5.1 yfinance-0.2.3 zipp-3.11.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
Creating virtualenv pyportfolioopt-SZ_KFjxI-py3.9 in /root/.cache/pypoetry/virtualenvs
Installing dependencies from lock file

Package operations: 115 installs, 0 updates, 0 removals

  • Installing attrs (22.1.0)
  • Installing platformdirs (2.5.4)
  • Installing pyrsistent (0.19.2)
  • Installing six (1.16.0)
  • Installing traitlets (5.5.0)
  • Installing entrypoints (0.4)
  • Installing fastjsonschema (2.16.2)
  • Installing jsonschema (4.17.1)
  • Installing jupyter-core (5.0.0)
  • Installing nest-asyncio (1.5.6)
  • Installing pycparser (2.21)
  • Installing python-dateutil (2.8.2)
  • Installing pyzmq (24.0.1)
  • Installing tornado (6.2)
  • Installing cffi (1.15.1)
  • Installing jupyter-client (7.4.7)
  • Installing markupsafe (2.1.1)
  • Installing nbformat (5.7.0)
  • Installing pyparsing (3.0.9)
  • Installing webencodings (0.5.1)
  • Installing zipp (3.11.0)
  • Installing soupsieve (2.3.2.post1)
  • Installing argon2-cffi-bindings (21.2.0)
  • Installing asttokens (2.1.0)
  • Installing beautifulsoup4 (4.11.1)
  • Installing bleach (5.0.1)
  • Installing executing (1.2.0)
  • Installing idna (3.4)
  • Installing defusedxml (0.7.1)
  • Installing importlib-metadata (5.1.0)
  • Installing jinja2 (3.1.2)
  • Installing jupyterlab-pygments (0.2.2)
  • Installing mistune (2.0.4)
  • Installing nbclient (0.7.0)
  • Installing packaging (21.3)
  • Installing pandocfilters (1.5.0)
  • Installing parso (0.8.3)
  • Installing ptyprocess (0.7.0)
  • Installing pure-eval (0.2.2)
  • Installing pygments (2.13.0)
  • Installing sniffio (1.3.0)
  • Installing tinycss2 (1.2.1)
  • Installing wcwidth (0.2.5)
  • Installing anyio (3.6.2)
  • Installing argon2-cffi (21.3.0)
  • Installing backcall (0.2.0)
  • Installing decorator (5.1.1)
  • Installing jedi (0.18.2)
  • Installing matplotlib-inline (0.1.6)
  • Installing pexpect (4.8.0)
  • Installing nbconvert (7.2.5)
  • Installing pickleshare (0.7.5)
  • Installing prometheus-client (0.15.0)
  • Installing prompt-toolkit (3.0.33)
  • Installing send2trash (1.8.0)
  • Installing stack-data (0.6.1)
  • Installing terminado (0.17.0)
  • Installing websocket-client (1.4.2)
  • Installing comm (0.1.1)
  • Installing debugpy (1.6.3)
  • Installing ipython (8.6.0)
  • Installing jupyter-server (1.23.3)
  • Installing numpy (1.23.5)
  • Installing psutil (5.9.4)
  • Installing certifi (2022.9.24)
  • Installing charset-normalizer (2.1.1)
  • Installing ipykernel (6.18.0)
  • Installing ipython-genutils (0.2.0)
  • Installing notebook-shim (0.2.2)
  • Installing pytz (2022.6)
  • Installing scipy (1.9.3)
  • Installing urllib3 (1.26.13)
  • Installing babel (2.11.0)
  • Installing exceptiongroup (1.0.4)
  • Installing iniconfig (1.1.1)
  • Installing json5 (0.9.10)
  • Installing nbclassic (0.4.8)
  • Installing qdldl (0.1.5.post2)
  • Installing requests (2.28.1)
  • Installing pluggy (1.0.0)
  • Installing tomli (2.0.1)
  • Installing typing-extensions (4.4.0)
  • Installing appdirs (1.4.4)
  • Installing click (8.1.3)
  • Installing contourpy (1.0.6)
  • Installing coverage (6.5.0)
  • Installing ecos (2.0.10)
  • Installing joblib (1.2.0)
  • Installing fonttools (4.38.0)
  • Installing cycler (0.11.0)
  • Installing jupyterlab-server (2.16.3)
  • Installing kiwisolver (1.4.4)
  • Installing lxml (4.9.1)
  • Installing mccabe (0.6.1)
  • Installing multitasking (0.0.11)
  • Installing mypy-extensions (0.4.3)
  • Installing notebook (6.5.2)
  • Installing osqp (0.6.2.post8)
  • Installing pandas (1.5.2)
  • Installing pathspec (0.10.2)
  • Installing pillow (9.3.0)
  • Installing pycodestyle (2.8.0)
  • Installing pyflakes (2.4.0)
  • Installing pytest (7.2.0)
  • Installing scs (3.2.2)
  • Installing setuptools-scm (7.0.5)
  • Installing threadpoolctl (3.1.0)
  • Installing black (22.10.0)
  • Installing cvxpy (1.2.2)
  • Installing flake8 (4.0.1)
  • Installing jupyterlab (3.5.0)
  • Installing matplotlib (3.6.2)
  • Installing pytest-cov (3.0.0)
  • Installing yfinance (0.1.87)
  • Installing scikit-learn (1.1.3)
Warning: The file chosen for install of ipykernel 6.18.0 (ipykernel-6.18.0-py3-none-any.whl) is yanked. Reason for being yanked: Breaking change in Comm
Removing intermediate container 000b65f1574a
 ---> f6b7423182ab
Step 5/6 : COPY . .
 ---> cd78218c00d6
Step 6/6 : RUN cd cookbook
 ---> Running in c17bbd72084c
Removing intermediate container c17bbd72084c
 ---> 25085e46ebea
Successfully built 25085e46ebea
Successfully tagged pypfopt:latest
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
Python 3.9.16
========================================================================== test session starts ==========================================================================
platform linux -- Python 3.9.16, pytest-7.2.0, pluggy-1.0.0
rootdir: /pypfopt
plugins: anyio-3.6.2, cov-3.0.0
collected 312 items                                                                                                                                                     

tests/test_base_optimizer.py ...................                                                                                                                  [  6%]
tests/test_black_litterman.py .....................                                                                                                               [ 12%]
tests/test_cla.py ............                                                                                                                                    [ 16%]
tests/test_custom_objectives.py ..................                                                                                                                [ 22%]
tests/test_discrete_allocation.py .................                                                                                                               [ 27%]
tests/test_efficient_cdar.py ....................                                                                                                                 [ 34%]
tests/test_efficient_cvar.py .....................                                                                                                                [ 41%]
tests/test_efficient_frontier.py ..........................................................................                                                       [ 64%]
tests/test_efficient_semivariance.py ............................                                                                                                 [ 73%]
tests/test_expected_returns.py ...................                                                                                                                [ 79%]
tests/test_hrp.py ......                                                                                                                                          [ 81%]
tests/test_imports.py ...                                                                                                                                         [ 82%]
tests/test_objective_functions.py ...........                                                                                                                     [ 86%]
tests/test_plotting.py .................                                                                                                                          [ 91%]
tests/test_risk_models.py ..........................                                                                                                              [100%]

=========================================================================== warnings summary ============================================================================
pypfopt/plotting.py:21
  /pypfopt/pypfopt/plotting.py:21: MatplotlibDeprecationWarning: The seaborn styles shipped by Matplotlib are deprecated since 3.6, as they no longer correspond to the styles shipped by seaborn. However, they will remain available as 'seaborn-v0_8-<style>'. Alternatively, directly use the seaborn API instead.
    plt.style.use("seaborn-deep")

tests/test_base_optimizer.py::test_exception_immutability
  /pypfopt/pypfopt/efficient_frontier/efficient_frontier.py:175: RuntimeWarning: Market neutrality requires shorting - bounds have been amended
    warnings.warn(

tests/test_black_litterman.py: 12 warnings
  /pypfopt/pypfopt/black_litterman.py:257: UserWarning: Running Black-Litterman with no prior.
    warnings.warn("Running Black-Litterman with no prior.")

tests/test_discrete_allocation.py: 9 warnings
tests/test_efficient_cvar.py: 1 warning
tests/test_efficient_semivariance.py: 2 warnings
tests/test_plotting.py: 4 warnings
  /root/.cache/pypoetry/virtualenvs/pyportfolioopt-SZ_KFjxI-py3.9/lib/python3.9/site-packages/cvxpy/problems/problem.py:1337: UserWarning: Solution may be inaccurate. Try another solver, adjusting the solver settings, or solve with verbose=True for more information.
    warnings.warn(

tests/test_efficient_frontier.py::test_min_volatility_sector_constraints
  /pypfopt/pypfopt/base_optimizer.py:397: UserWarning: Sector constraints may not produce reasonable results if shorts are allowed.
    warnings.warn(

tests/test_efficient_frontier.py::test_max_sharpe_L2_reg_different_gamma
tests/test_efficient_frontier.py::test_max_sharpe_L2_reg_different_gamma
tests/test_efficient_frontier.py::test_max_sharpe_L2_reg_reduces_sharpe
tests/test_efficient_frontier.py::test_max_sharpe_L2_reg_with_shorts
  /pypfopt/pypfopt/efficient_frontier/efficient_frontier.py:262: UserWarning: max_sharpe transforms the optimization problem so additional objectives may not work as expected.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================== 312 passed, 35 warnings in 87.43s (0:01:27) ==============================================================
```