### PR TITLE
fixed key error when adding multiple sector constraints

### DIFF
--- a/pypfopt/base_optimizer.py
+++ b/pypfopt/base_optimizer.py
@@ -397,10 +397,10 @@ class BaseConvexOptimizer(BaseOptimizer):
                 "Sector constraints may not produce reasonable results if shorts are allowed."
             )
         for sector in sector_upper:
-            is_sector = [sector_mapper[t] == sector for t in self.tickers]
+            is_sector = [sector_mapper.get(t) == sector for t in self.tickers]
             self.add_constraint(lambda w: cp.sum(w[is_sector]) <= sector_upper[sector])
         for sector in sector_lower:
-            is_sector = [sector_mapper[t] == sector for t in self.tickers]
+            is_sector = [sector_mapper.get(t) == sector for t in self.tickers]
             self.add_constraint(lambda w: cp.sum(w[is_sector]) >= sector_lower[sector])
 
     def convex_objective(self, custom_objective, weights_sum_to_one=True, **kwargs):


### PR DESCRIPTION
I wanted to add multiple sector constraints, for example:

```python
mapper1 = {
     "AAPL": "ESG",
     "PG": "NOTESG"
     . 
     .
     .
   }
lower1 = {
    "ESG": 0.1
}
upper1 = {
    "NOTESG": 0.1
}

ef.add_sector_constraint(mapper1, lower1, upper1)


mapper2 = {
     "AAPL": "TECH",
     "PG": "DEFENSIVE"
     . 
     .
     .
   }
lower2 = {
    "DEFENSIVE": 0.1
}
upper2 = {
    "TECH": 0.2
}

ef.add_sector_constraint(mapper2, lower2, upper2)
```

Where the main problem was that some assets belonged to more than one sector, and wanted to mix different sector classifications, such as debt can be subdivided between corporate and governmental.

 When adding the second constraint, it looks for all registered tickers, where some may not be present in the second mapper, thus by changed the [] dict indexing notation for a .get notation, a None is returned, and therefore not added to the optimization constraint sum in:
 
 ```python
        for sector in sector_upper:
            is_sector = [sector_mapper.get(t) == sector for t in self.tickers]
            self.add_constraint(lambda w: cp.sum(w[is_sector]) <= sector_upper[sector])
        for sector in sector_lower:
            is_sector = [sector_mapper.get(t) == sector for t in self.tickers]
            self.add_constraint(lambda w: cp.sum(w[is_sector]) >= sector_lower[sector])
``` 
