### PR TITLE
Fixed matplotlib plot style

### DIFF
--- a/pypfopt/plotting.py
+++ b/pypfopt/plotting.py
@@ -17,7 +17,7 @@ import scipy.cluster.hierarchy as sch
 from . import CLA, EfficientFrontier, exceptions, risk_models
 
 try:
-    plt.style.use("seaborn-deep")
+    plt.style.use("seaborn-v0_8-deep")
 except Exception:  # pragma: no cover
     pass
 


### PR DESCRIPTION
MatplotlibDeprecationWarning: The seaborn styles shipped by Matplotlib are deprecated since 3.6, as they no longer correspond to the styles shipped by seaborn. However, they will remain available as 'seaborn-v0_8-<style>'

Fixes
https://github.com/robertmartin8/PyPortfolioOpt/issues/581