### PR TITLE
Fix dtype warning in HRPOpt: cast weights to float before multiplication

### DIFF
--- a/pypfopt/hierarchical_portfolio.py
+++ b/pypfopt/hierarchical_portfolio.py
@@ -135,6 +135,7 @@ class HRPOpt(base_optimizer.BaseOptimizer):
                 first_variance = HRPOpt._get_cluster_var(cov, first_cluster)
                 second_variance = HRPOpt._get_cluster_var(cov, second_cluster)
                 alpha = 1 - first_variance / (first_variance + second_variance)
+                w = w.astype('float64')
                 w[first_cluster] *= alpha  # weight 1
                 w[second_cluster] *= 1 - alpha  # weight 2
         return w


### PR DESCRIPTION
## Description  
This addresses a Future Warning in `pypfopt/hierarchical_portfolio.py` caused by multiplying integer-type weights with float values. Due to stricter type enforcement, this would cause errors in future pandas versions.

## Files Changed
- `pypfopt/hierarchical_portfolio.py`

## Fix  
Explicitly cast weights array to float64 before arithmetic operations:

```
# Before
w[first_cluster] *= alpha  # weight 1

# After
w = w.astype('float64')  # ensure the weights array is float64
w[first_cluster] *= alpha  # weight 1
```

## Testing Performed
- [x] Ran full test suite with `pytest` (no failures)
- [x] Manually verified warning elimination
- [x] Confirmed HRP optimization consistency

## Checklist  
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] Unit tests pass
- [x] No unintended side effects

This patch ensures floating-point arithmetic and prevents future dtype conflicts in pandas.
