### PR TITLE
[MNT] CI: concurrency and no fail-fast

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: ["main"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pytest:
     name: py${{ matrix.python-version }} on ${{ matrix.os }}
@@ -19,6 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false  # to not fail all combinations if just one fails
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
* introduces limited concurrency for CI jobs, so CI only runs on the newest commit of a branch and cancels other runs, to save runners
* forces all started CI runs to conclude by adding `fail-fast: False`