### PR TITLE
[MNT] move CI installs to `uv`

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: uv pip install ".[dev,all_extras]" --no-cache-dir
+        env:
+          UV_SYSTEM_PYTHON: 1
 
       - name: Show dependencies
         run: uv pip list

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: uv pip install ".[dev,all_extras]" --no-cache-dir
+        env:
+          UV_SYSTEM_PYTHON: 1
 
       - name: Show dependencies
         run: uv pip list


### PR DESCRIPTION
Moves the CI installs to `uv` - this has no impact on the packaging or UX, but speeds up the CI VM setup significantly.

Also adds a display step for installed packages for potential diagnostics.