### PR TITLE
[MNT] ensure release workflow runs only after tag check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
   build_wheels:
     name: Build wheels
     runs-on: ubuntu-latest
+    needs: [check_tag]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Ensure the `check_tag` workflow that checks validity of the release tag in `release.yml` is the first condition that needs to be satisfied for an actual release happening.

Previously, it ran but was not one of the gates.