### PR TITLE
[ENH] Add test to validate execution of README Python examples

### DIFF
--- a/tests/test_discrete_allocation.py
+++ b/tests/test_discrete_allocation.py
@@ -1,7 +1,7 @@
+from cvxpy.error import SolverError
 import numpy as np
 import pandas as pd
 import pytest
-from cvxpy.error import SolverError
 
 from pypfopt.discrete_allocation import DiscreteAllocation, get_latest_prices
 from tests.utilities_for_tests import get_data, setup_efficient_frontier

--- a/tests/test_efficient_frontier.py
+++ b/tests/test_efficient_frontier.py
@@ -608,7 +608,7 @@ def test_min_vol_pair_constraint():
     ef.min_volatility()
     old_sum = ef.weights[:2].sum()
     ef = setup_efficient_frontier()
-    ef.add_constraint(lambda w: (w[1] + w[0] <= old_sum / 2))
+    ef.add_constraint(lambda w: w[1] + w[0] <= old_sum / 2)
     ef.min_volatility()
     new_sum = ef.weights[:2].sum()
     assert new_sum <= old_sum / 2 + 1e-4
@@ -620,7 +620,7 @@ def test_max_sharpe_pair_constraint():
     old_sum = ef.weights[:2].sum()
 
     ef = setup_efficient_frontier()
-    ef.add_constraint(lambda w: (w[1] + w[0] <= old_sum / 2))
+    ef.add_constraint(lambda w: w[1] + w[0] <= old_sum / 2)
     ef.max_sharpe(risk_free_rate=0.02)
     new_sum = ef.weights[:2].sum()
     assert new_sum <= old_sum / 2 + 1e-4

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -1,7 +1,7 @@
 import os
+from pathlib import Path
 import re
 import sys
-from pathlib import Path
 
 README_PATH = Path(__file__).resolve().parent.parent / "README.md"
 
@@ -33,9 +33,7 @@ def test_readme_python_examples_run():
             exec(block, globals_dict)
 
     except Exception as e:
-        raise AssertionError(
-            f"README python block #{idx} failed:\n{block}"
-        ) from e
+        raise AssertionError(f"README python block #{idx} failed:\n{block}") from e
 
     finally:
         os.chdir(old_cwd)


### PR DESCRIPTION
Adds a pytest that parses `README.md` and executes all python code blocks to ensure examples remain valid.

Closes #669 

- Uses regex to extract Python blocks
- Executes them sequentially in a shared namespace (since examples are stateful)
- Runs from repo root so relative paths like `tests/resources/...` resolve correctly
- Adds repo root to `sys.path` so `pypfopt` can be imported without installation

This verifies that README examples run as documented and helps prevent regressions in imports or usage.