### PR TITLE
[ENH] downwards compatible exports of `base_optimizer` module

### DIFF
--- a/pypfopt/base_optimizer.py
+++ b/pypfopt/base_optimizer.py
@@ -1,0 +1,9 @@
+"""Exports for _base_optimizer.py, for downwards compatibility."""
+
+from pypfopt.base._base_optimizer import (
+    BaseConvexOptimizer,
+    BaseOptimizer,
+    portfolio_performance,
+)
+
+__all__ = ["BaseOptimizer", "BaseConvexOptimizer", "portfolio_performance"]


### PR DESCRIPTION
Adds back downwards compatible exports of `base_optimizer` module, following #714