### PR TITLE
Fix pytest-randomly seed overflow in numpy legacy API

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,18 +7,14 @@ random seed API. See https://github.com/PyPortfolio/PyPortfolioOpt/issues/725
 import numpy as np
 
 _original_np_random_seed = np.random.seed
+_UINT32_MODULUS = 2**32
 
 
 def _safe_np_random_seed(seed=None):
-      """Constrain seed to numpy's valid range [0, 2**32 - 1].
-
-          pytest-randomly may generate seeds exceeding this range when combining
-              the base seed with per-test offsets, causing ValueError in numpy's
-                  legacy random API.
-                      """
-      if seed is not None and isinstance(seed, (int, np.integer)):
-                seed = seed % (2**32)
-            _original_np_random_seed(seed)
+    """Wrap oversized nonnegative integer seeds into NumPy's valid range."""
+    if isinstance(seed, (int, np.integer)) and seed >= _UINT32_MODULUS:
+        seed = seed % _UINT32_MODULUS
+    _original_np_random_seed(seed)
 
 
 np.random.seed = _safe_np_random_seed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Pytest configuration for PyPortfolioOpt tests.
+
+Fixes compatibility between pytest-randomly and numpy's legacy
+random seed API. See https://github.com/PyPortfolio/PyPortfolioOpt/issues/725
+"""
+
+import numpy as np
+
+_original_np_random_seed = np.random.seed
+
+
+def _safe_np_random_seed(seed=None):
+      """Constrain seed to numpy's valid range [0, 2**32 - 1].
+
+          pytest-randomly may generate seeds exceeding this range when combining
+              the base seed with per-test offsets, causing ValueError in numpy's
+                  legacy random API.
+                      """
+      if seed is not None and isinstance(seed, (int, np.integer)):
+                seed = seed % (2**32)
+            _original_np_random_seed(seed)
+
+
+np.random.seed = _safe_np_random_seed

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -5,42 +5,46 @@ import pytest
 
 
 class TestSafeNumpySeed:
-      """Verify numpy.random.seed handles oversized seeds from pytest-randomly."""
+    """Verify numpy.random.seed handles oversized seeds from pytest-randomly."""
 
     def test_seed_exceeding_uint32_max(self):
-              """Seeds above 2**32 - 1 should not raise ValueError."""
-              np.random.seed(2**32 + 12345)
+        """Seeds above 2**32 - 1 should not raise ValueError."""
+        np.random.seed(2**32 + 12345)
 
     def test_seed_at_uint32_boundary(self):
-              """Seed exactly at 2**32 should wrap to 0."""
-              np.random.seed(2**32)
+        """Seed exactly at 2**32 should wrap to 0."""
+        np.random.seed(2**32)
 
     def test_seed_zero(self):
-              """Seed 0 should work as normal."""
-              np.random.seed(0)
+        """Seed 0 should work as normal."""
+        np.random.seed(0)
 
     def test_seed_max_valid(self):
-              """Seed 2**32 - 1 should work as normal."""
-              np.random.seed(2**32 - 1)
+        """Seed 2**32 - 1 should work as normal."""
+        np.random.seed(2**32 - 1)
 
     def test_seed_none(self):
-              """Seed None should work as normal (random seed)."""
-              np.random.seed(None)
+        """Seed None should work as normal (random seed)."""
+        np.random.seed(None)
+
+    def test_negative_seed_still_raises(self):
+        """Negative seeds should keep NumPy's original validation behavior."""
+        with pytest.raises(ValueError):
+            np.random.seed(-1)
 
     def test_determinism_preserved(self):
-              """Patched seed should still produce deterministic results."""
-              np.random.seed(42)
-              a = np.random.rand(5)
-              np.random.seed(42)
-              b = np.random.rand(5)
-              np.testing.assert_array_equal(a, b)
+        """Patched seed should still produce deterministic results."""
+        np.random.seed(42)
+        a = np.random.rand(5)
+        np.random.seed(42)
+        b = np.random.rand(5)
+        np.testing.assert_array_equal(a, b)
 
-    def test_large_seed_determinism(self):
-              """Oversized seeds should produce deterministic results."""
-              large_seed = 2**33 + 99
-              np.random.seed(large_seed)
-              a = np.random.rand(5)
-              np.random.seed(large_seed)
-              b = np.random.rand(5)
-              np.testing.assert_array_equal(a, b)
-      
+    def test_large_seed_matches_wrapped_seed(self):
+        """Oversized seeds should behave like their uint32-wrapped value."""
+        large_seed = 2**33 + 99
+        np.random.seed(large_seed)
+        a = np.random.rand(5)
+        np.random.seed(99)
+        b = np.random.rand(5)
+        np.testing.assert_array_equal(a, b)

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,0 +1,46 @@
+"""Tests for the conftest.py seed safety patch."""
+
+import numpy as np
+import pytest
+
+
+class TestSafeNumpySeed:
+      """Verify numpy.random.seed handles oversized seeds from pytest-randomly."""
+
+    def test_seed_exceeding_uint32_max(self):
+              """Seeds above 2**32 - 1 should not raise ValueError."""
+              np.random.seed(2**32 + 12345)
+
+    def test_seed_at_uint32_boundary(self):
+              """Seed exactly at 2**32 should wrap to 0."""
+              np.random.seed(2**32)
+
+    def test_seed_zero(self):
+              """Seed 0 should work as normal."""
+              np.random.seed(0)
+
+    def test_seed_max_valid(self):
+              """Seed 2**32 - 1 should work as normal."""
+              np.random.seed(2**32 - 1)
+
+    def test_seed_none(self):
+              """Seed None should work as normal (random seed)."""
+              np.random.seed(None)
+
+    def test_determinism_preserved(self):
+              """Patched seed should still produce deterministic results."""
+              np.random.seed(42)
+              a = np.random.rand(5)
+              np.random.seed(42)
+              b = np.random.rand(5)
+              np.testing.assert_array_equal(a, b)
+
+    def test_large_seed_determinism(self):
+              """Oversized seeds should produce deterministic results."""
+              large_seed = 2**33 + 99
+              np.random.seed(large_seed)
+              a = np.random.rand(5)
+              np.random.seed(large_seed)
+              b = np.random.rand(5)
+              np.testing.assert_array_equal(a, b)
+      


### PR DESCRIPTION
Closes #725

### Problem

When `pytest-randomly` (older versions) generates seeds that exceed `2**32 - 1`, `numpy.random.seed()` raises a `ValueError` because its legacy API only accepts seeds in the range `[0, 2**32 - 1]`.

```
ValueError: Seed must be between 0 and 2**32 - 1
```

This surfaces as random, hard-to-reproduce test failures depending on the seed pytest-randomly picks.

### Fix

Adds a `tests/conftest.py` that monkey-patches `numpy.random.seed` at module load time to constrain any integer seed via `seed % (2**32)`. Non-integer and `None` seeds pass through unchanged.

The patch is minimal and project-scoped - it only affects the test suite, not library code.

### Tests

Adds `tests/test_conftest.py` with 7 tests covering:

- Seeds exceeding uint32 max
- - Seed at the uint32 boundary (2**32)
- - Seed zero
- - Seed at max valid value (2**32 - 1)
- - Seed None (random)
- - Determinism preserved after patching
- - Large seed determinism (consistent wrapping)
All tests pass. Both files are Black-formatted.

### Reproduction

```bash
pip install pytest-randomly==1.2.3
pytest tests/ -p randomly --randomly-seed=5765063658
# ValueError: Seed must be between 0 and 2**32 - 1

# With the fix applied:
pytest tests/ -p randomly --randomly-seed=5765063658
# All tests pass
```