### PR TITLE
Fix CLA max_sharpe with equal expected returns

### DIFF
--- a/pypfopt/cla.py
+++ b/pypfopt/cla.py
@@ -364,8 +364,8 @@ class CLA(BaseOptimizer):
                         self.w[-1][i],
                     )
                     if (
-                        self.ls[-1] is None or lam < self.ls[-1]
-                    ) and lam > CLA._infnone(l_out):
+                        self.ls[-1] is None or CLA._infnone(lam) < self.ls[-1]
+                    ) and CLA._infnone(lam) > CLA._infnone(l_out):
                         l_out, i_out = lam, i
             if (l_in is None or l_in < 0) and (l_out is None or l_out < 0):
                 # 3) compute minimum variance solution

--- a/tests/test_cla.py
+++ b/tests/test_cla.py
@@ -52,6 +52,19 @@ def test_cla_max_sharpe_short():
     assert sharpe > long_only_sharpe
 
 
+def test_cla_max_sharpe_equal_returns_matches_min_volatility():
+    mu = np.array([0.1, 0.1])
+    S = np.array([[0.01, 0.01], [0.01, 0.02]])
+
+    cla = CLA(mu, S)
+    w = cla.max_sharpe()
+
+    min_vol_cla = CLA(mu, S)
+    min_vol_w = min_vol_cla.min_volatility()
+    assert w == min_vol_w
+    np.testing.assert_allclose(cla.weights, min_vol_cla.weights)
+
+
 def test_cla_custom_bounds():
     bounds = [(0.01, 0.13), (0.02, 0.11)] * 10
     cla = setup_cla(weight_bounds=bounds)


### PR DESCRIPTION
#### Description

Fixes #738.

This fixes a `TypeError` in `CLA.max_sharpe()` when all expected returns are equal.

In this edge case, `_compute_lambda()` can return `None` for `lam`, but `_solve()` later compares `lam` against floats. This PR applies the existing `CLA._infnone()` helper consistently in the lambda comparison path, allowing the algorithm to fall through deterministically to the minimum-volatility solution.

#### Changes

* Adds a regression test using the sample from #738.
* Verifies `max_sharpe()` no longer crashes for equal expected returns.
* Verifies the result matches `min_volatility()` for that edge case.
* Keeps the CLA logic change narrow and localized.

#### Validation

* `uv run --extra dev pytest tests/test_cla.py`
* `uv run --with ruff ruff check pypfopt/cla.py tests/test_cla.py`
* `git diff --check`
