### PR TITLE
[BUG] raise an informative error when CLA gets a singular covariance matrix

### DIFF
--- a/pypfopt/cla.py
+++ b/pypfopt/cla.py
@@ -192,6 +192,45 @@ class CLA(BaseOptimizer):
         res = float(res[0, 0])
         return res, bi
 
+    @staticmethod
+    def _invert_covar_free(covarF):
+        """
+        Invert the covariance submatrix of the currently free assets.
+
+        The critical line algorithm requires this submatrix to be invertible. A
+        singular covariance matrix – e.g. one containing perfectly correlated or
+        duplicated assets, or estimated from fewer observations than assets – can
+        make it singular, in which case numpy raises a bare ``LinAlgError`` from
+        deep inside the algorithm. Translate it into an actionable error instead.
+
+        Parameters
+        ----------
+        covarF : np.ndarray
+            covariance submatrix of the free assets
+
+        Raises
+        ------
+        ValueError
+            if the submatrix is singular
+
+        Returns
+        -------
+        np.ndarray
+            inverse of ``covarF``
+        """
+        try:
+            return np.linalg.inv(covarF)
+        except np.linalg.LinAlgError:
+            raise ValueError(
+                "The covariance matrix is singular, so the critical line algorithm "
+                "cannot invert it. This usually means some assets are perfectly "
+                "correlated or duplicated, or that the covariance matrix was "
+                "estimated from fewer observations than there are assets. Consider "
+                "removing redundant assets, or using a shrinkage estimator such as "
+                "risk_models.CovarianceShrinkage, which returns a positive definite "
+                "matrix."
+            ) from None
+
     def _get_matrices(self, f):
         # Slice covarF,covarFB,covarB,meanF,meanB,wF,wB
         covarF = self._reduce_matrix(self.cov_matrix, f, f)
@@ -339,7 +378,7 @@ class CLA(BaseOptimizer):
             l_in = None
             if len(f) > 1:
                 covarF, covarFB, meanF, wB = self._get_matrices(f)
-                covarF_inv = np.linalg.inv(covarF)
+                covarF_inv = self._invert_covar_free(covarF)
                 j = 0
                 for i in f:
                     lam, bi = self._compute_lambda(
@@ -354,7 +393,7 @@ class CLA(BaseOptimizer):
                 b = self._get_b(f)
                 for i in b:
                     covarF, covarFB, meanF, wB = self._get_matrices(f + [i])
-                    covarF_inv = np.linalg.inv(covarF)
+                    covarF_inv = self._invert_covar_free(covarF)
                     lam, bi = self._compute_lambda(
                         covarF_inv,
                         covarFB,
@@ -371,7 +410,7 @@ class CLA(BaseOptimizer):
                 # 3) compute minimum variance solution
                 self.ls.append(0)
                 covarF, covarFB, meanF, wB = self._get_matrices(f)
-                covarF_inv = np.linalg.inv(covarF)
+                covarF_inv = self._invert_covar_free(covarF)
                 meanF = np.zeros(meanF.shape)
             else:
                 # 4) decide lambda
@@ -383,7 +422,7 @@ class CLA(BaseOptimizer):
                     self.ls.append(l_out)
                     f.append(i_out)
                 covarF, covarFB, meanF, wB = self._get_matrices(f)
-                covarF_inv = np.linalg.inv(covarF)
+                covarF_inv = self._invert_covar_free(covarF)
             # 5) compute solution vector
             wF, g = self._compute_w(covarF_inv, covarFB, meanF, wB)
             for i in range(len(f)):

--- a/tests/test_cla.py
+++ b/tests/test_cla.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pypfopt import risk_models
+from pypfopt import expected_returns, risk_models
 from pypfopt.cla import CLA
 from tests.utilities_for_tests import get_data, setup_cla
 
@@ -94,6 +94,42 @@ def test_cla_two_assets():
     mu = np.array([[0.02569294], [0.16203987]])
     cov = np.array([[0.0012765, -0.00212724], [-0.00212724, 0.01616983]])
     assert CLA(mu, cov)
+
+
+def test_cla_singular_covariance_raises():
+    # Perfectly correlated assets give a positive semidefinite but singular
+    # covariance matrix, which CLA cannot invert. The user should get an
+    # actionable error rather than a bare numpy LinAlgError.
+    mu = np.array([0.1, 0.2])
+    cov = np.array([[0.01, 0.01], [0.01, 0.01]])
+
+    for method in ("max_sharpe", "min_volatility", "efficient_frontier"):
+        with pytest.raises(ValueError, match="cannot invert") as e:
+            getattr(CLA(mu, cov), method)()
+        # np.linalg.LinAlgError subclasses ValueError, so assert explicitly that
+        # the raw numpy error is not what surfaces to the user.
+        assert not isinstance(e.value, np.linalg.LinAlgError)
+
+
+def test_cla_singular_covariance_fixed_by_shrinkage():
+    # The remedy suggested by the error message should actually work: shrinkage
+    # returns a positive definite matrix, which CLA can handle.
+    df = get_data()
+    # duplicate a column to make the sample covariance singular
+    df = df.iloc[:, :3].copy()
+    df[df.columns[1]] = df[df.columns[0]]
+    mu = expected_returns.mean_historical_return(df)
+
+    sample_cov = risk_models.sample_cov(df)
+    assert np.min(np.linalg.eigvalsh(sample_cov)) < 1e-12
+    with pytest.raises(ValueError, match="cannot invert"):
+        CLA(mu, sample_cov).min_volatility()
+
+    shrunk_cov = risk_models.CovarianceShrinkage(df).ledoit_wolf()
+    assert np.min(np.linalg.eigvalsh(shrunk_cov)) > 0
+    w = CLA(mu, shrunk_cov).min_volatility()
+    assert len(w) == 3
+    np.testing.assert_almost_equal(sum(w.values()), 1)
 
 
 def test_cla_max_sharpe_semicovariance():


### PR DESCRIPTION
Closes #737

## Summary

`CLA` inverts the covariance submatrix of the free assets on every iteration. When the covariance matrix is singular — perfectly correlated or duplicated assets, or fewer observations than assets — that inversion can fail, and the user gets a bare `numpy.linalg.LinAlgError: Singular matrix` thrown from a private method, with no hint as to the cause or the fix.

This routes the four inversion sites through a small helper that translates `LinAlgError` into a `ValueError` naming the likely cause and pointing at concrete remedies.

Before:
```
numpy.linalg.LinAlgError: Singular matrix
```

After:
```
ValueError: The covariance matrix is singular, so the critical line algorithm cannot
invert it. This usually means some assets are perfectly correlated or duplicated, or
that the covariance matrix was estimated from fewer observations than there are assets.
Consider removing redundant assets, or using a shrinkage estimator such as
risk_models.CovarianceShrinkage, which returns a positive definite matrix.
```

## Why not validate up front?

The issue suggests raising a validation error before optimisation begins. I tried that first and backed it out — it is a **regression**. A singular covariance matrix only breaks CLA if a submatrix *of the currently free assets* happens to be singular, which often never occurs. Over 40 randomly generated rank-deficient covariance matrices, **29 solved fine and only 4 raised `LinAlgError`**, so an up-front positive-definiteness check would reject a majority of inputs that work today.

Worth noting for anyone reaching for the existing helper: `risk_models._is_positive_semidefinite` returns `True` for these singular matrices (it adds `1e-16` jitter before the Cholesky), so it is not a usable guard here — CLA needs positive *definiteness*, not semidefiniteness.

Translating the error where it actually occurs keeps the working cases working and only improves the failing path. Verified: the same 29 still succeed, and the 4 `LinAlgError`s become clear `ValueError`s.

## Tests

Two tests added:

- `test_cla_singular_covariance_raises` — the exact reproducer from the issue, across `max_sharpe` / `min_volatility` / `efficient_frontier`. Note it asserts the error is **not** a `LinAlgError`: `np.linalg.LinAlgError` subclasses `ValueError`, so a plain `pytest.raises(ValueError)` would pass against the old code and prove nothing.
- `test_cla_singular_covariance_fixed_by_shrinkage` — verifies the remedy the error message recommends actually works, i.e. that `CovarianceShrinkage` returns a positive definite matrix CLA can solve. An error message giving advice should have that advice tested.

Both fail on `main` and pass here. Full suite: 281 passed. The 5 failures in `test_hrp.py` are pre-existing on a clean `main` (a `scipy.cluster` incompatibility) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)