### PR TITLE
[BUG] fix HRPOpt.optimize raising AttributeError under scipy >= 1.18

### DIFF
--- a/pypfopt/hierarchical_portfolio.py
+++ b/pypfopt/hierarchical_portfolio.py
@@ -176,9 +176,6 @@ class HRPOpt(BaseOptimizer):
         OrderedDict
             weights for the HRP portfolio
         """
-        if linkage_method not in sch._LINKAGE_METHODS:
-            raise ValueError("linkage_method must be one recognised by scipy")
-
         if self.returns is None:
             cov = self.cov_matrix
             corr = cov_to_corr(self.cov_matrix).round(6)

--- a/tests/test_hrp.py
+++ b/tests/test_hrp.py
@@ -78,3 +78,26 @@ def test_quasi_dag():
     hrp.optimize(linkage_method="single")
     clusters = hrp.clusters
     assert HRPOpt._get_quasi_diag(clusters)[:5] == [12, 6, 15, 14, 2]
+
+
+def test_hrp_linkage_methods():
+    # optimize() used to validate linkage_method against the private attribute
+    # sch._LINKAGE_METHODS, which scipy 1.18 removed, so every call raised
+    # AttributeError. scipy exposes no public list of linkage methods, so the
+    # seven documented by scipy.cluster.hierarchy.linkage are pinned here.
+    df = get_data()
+    returns = df.pct_change().dropna(how="all")
+    methods = [
+        "single",
+        "complete",
+        "average",
+        "weighted",
+        "centroid",
+        "median",
+        "ward",
+    ]
+    for method in methods:
+        hrp = HRPOpt(returns)
+        w = hrp.optimize(linkage_method=method)
+        assert set(w.keys()) == set(returns.columns)
+        np.testing.assert_almost_equal(sum(w.values()), 1)


### PR DESCRIPTION
Fixes item 3 of #750: `HRPOpt.optimize()` validates `linkage_method` against
`scipy.cluster.hierarchy._LINKAGE_METHODS`, a private attribute that scipy
1.18.0 removed, so every call raises `AttributeError` - including the default
`linkage_method="single"` - and CI is red on `main` (run 28899115146 at
`a6638d2`). `pyproject.toml` allows `scipy>=1.3.0` unbounded, so a fresh
install resolves the broken combination.

**Fix**: delete the pre-check. `scipy.cluster.hierarchy.linkage` validates the
method itself and raises `ValueError: Invalid method: <name>` before touching
data, so the documented `ValueError` contract holds - the existing
`test_hrp_errors` assertion passes unchanged - and no private-API dependency
remains.

**Test**: `test_hrp_linkage_methods` runs `optimize()` over the seven linkage
methods documented by `scipy.cluster.hierarchy.linkage` and checks each
returns a full set of weights summing to 1. scipy exposes no public list of
valid methods, so the test pins the documented seven.

Measured on Python 3.13.8 / scipy 1.18.0 / numpy 2.5.1 / pandas 3.0.5 with
`pytest ./tests -q`:

- `main`: 7 failed, 295 passed, 15 skipped - all seven failures are this
  `AttributeError` (five in `test_hrp.py`, two in `test_plotting.py`, both of
  which construct an `HRPOpt`).
- The new test alone on `main` fails with the same `AttributeError`.
- This branch: 303 passed, 15 skipped, 0 failed. `ruff check` and
  `ruff format` clean on both changed files.

If you would like an upper bound (`scipy>=1.3.0,<2.0.0`) so a future scipy
2.0 cannot repeat this failure mode, happy to add it here or as a separate
PR, whichever fits your dependency policy.
