### PR TITLE
Fix CLA.max_sharpe() TypeError when all expected returns are equal

### DIFF
--- a/pypfopt/cla.py
+++ b/pypfopt/cla.py
@@ -364,8 +364,8 @@ class CLA(BaseOptimizer):
                         self.w[-1][i],
                     )
                     if (
-                        self.ls[-1] is None or lam < self.ls[-1]
-                    ) and lam > CLA._infnone(l_out):
+                        self.ls[-1] is None or CLA._infnone(lam) < self.ls[-1]
+                    ) and CLA._infnone(lam) > CLA._infnone(l_out):
                         l_out, i_out = lam, i
             if (l_in is None or l_in < 0) and (l_out is None or l_out < 0):
                 # 3) compute minimum variance solution


### PR DESCRIPTION
## Summary
Fixes #738 — `CLA.max_sharpe()` raises `TypeError: '>' not supported between instances of 'NoneType' and 'float'` whenever all expected returns are equal.

**Root cause (as diagnosed in the issue):** `_compute_lambda` returns `(None, None)` when its denominator `c` is exactly zero, which is mathematically guaranteed when all expected returns are identical. In `_solve`, the case-a) branch (bounding a free weight) already guards against this by comparing `CLA._infnone(lam)` rather than the raw `lam`:

```python
if CLA._infnone(lam) > CLA._infnone(l_in):
```

But the case-b) branch (freeing a bounded weight), a few lines down, compares the raw `lam` directly:

```python
if (
    self.ls[-1] is None or lam < self.ls[-1]
) and lam > CLA._infnone(l_out):
```

When `lam` is `None`, both comparisons raise `TypeError`.

## Fix
Wrap `lam` with `CLA._infnone(...)` in both comparisons of the case-b) branch, mirroring the existing case-a) pattern:

```python
if (
    self.ls[-1] is None or CLA._infnone(lam) < self.ls[-1]
) and CLA._infnone(lam) > CLA._infnone(l_out):
```

`_infnone(None)` resolves to `-inf`, so a candidate with an undefined `lam` is simply never selected as `i_out`/`l_out` — consistent with how the case-a) branch already treats an undefined `lam` as "never the best candidate." No special-casing needed; the algorithm falls through naturally to the minimum-variance solution when no valid turning point exists, matching one of the two behaviors suggested in the issue.

## Test plan
- [x] Confirmed the fix is a minimal, one-pattern change that mirrors the existing `_infnone`-guarded comparison already present a few lines above in the same method (case-a) branch), so it doesn't introduce a new code pattern.
- [x] Traced through the reproduction case from the issue (`mu = [0.1, 0.1]`, `S = [[0.01, 0.01], [0.01, 0.02]]`) by hand against the patched logic — with `lam = None`, `CLA._infnone(lam) = -inf`, so the case-b) branch no longer raises and simply skips that candidate.
- [ ] Could not run the reproduction script directly in this environment (the `pypfopt` package `__init__` pulls in `cvxpy`, not installed here, and I didn't want to add a new dependency just to verify a two-line fix). Flagging for CI/maintainer verification — happy to iterate if anything surfaces.
