### PR TITLE
Fix HRP SciPy linkage method validation

### DIFF
--- a/pypfopt/hierarchical_portfolio.py
+++ b/pypfopt/hierarchical_portfolio.py
@@ -23,6 +23,17 @@ from pypfopt.base import BaseOptimizer, portfolio_performance
 from pypfopt.risk_models import cov_to_corr
 
 
+_VALID_LINKAGE_METHODS = {
+    "single",
+    "complete",
+    "average",
+    "weighted",
+    "centroid",
+    "median",
+    "ward",
+}
+
+
 class HRPOpt(BaseOptimizer):
     """
     A HRPOpt object (inheriting from BaseOptimizer) constructs a hierarchical
@@ -176,7 +187,7 @@ class HRPOpt(BaseOptimizer):
         OrderedDict
             weights for the HRP portfolio
         """
-        if linkage_method not in sch._LINKAGE_METHODS:
+        if linkage_method not in _VALID_LINKAGE_METHODS:
             raise ValueError("linkage_method must be one recognised by scipy")
 
         if self.returns is None:

--- a/tests/test_hrp.py
+++ b/tests/test_hrp.py
@@ -21,6 +21,21 @@ def test_hrp_errors():
         hrp.optimize(linkage_method="blah")
 
 
+@pytest.mark.parametrize(
+    "linkage_method",
+    ["single", "complete", "average", "weighted", "centroid", "median", "ward"],
+)
+def test_hrp_linkage_methods(linkage_method):
+    df = get_data()
+    returns = df.pct_change().dropna(how="all")
+    hrp = HRPOpt(returns)
+
+    weights = hrp.optimize(linkage_method=linkage_method)
+
+    assert isinstance(weights, dict)
+    np.testing.assert_almost_equal(sum(weights.values()), 1)
+
+
 def test_hrp_portfolio():
     df = get_data()
     returns = df.pct_change().dropna(how="all")


### PR DESCRIPTION
## Summary

Fixes #754

`HRPOpt.optimize()` failed with current SciPy versions because it accessed
the private `scipy.cluster.hierarchy._LINKAGE_METHODS` attribute.

## Changes

- Replace the private SciPy API usage with explicit supported linkage-method validation.
- Add regression tests for all supported linkage methods:
  - `single`
  - `complete`
  - `average`
  - `weighted`
  - `centroid`
  - `median`
  - `ward`

## Testing

- Targeted HRP and plotting tests: `31 passed`
- Full test suite: `320 passed, 4 skipped`

## Checklist

- [x] Tests added or updated
- [x] Documentation is not required for this internal compatibility fix
- [x] Existing behavior for invalid linkage methods is preserved